### PR TITLE
Compact dashboard UI and metric deduplication

### DIFF
--- a/web/src/components/metric-chart.tsx
+++ b/web/src/components/metric-chart.tsx
@@ -31,8 +31,8 @@ export function MetricChart({ metric, values, onHover, onRemove, className }: Me
 
   if (chartData.length === 0) {
     return (
-      <Card className={cn("rounded-2xl", className)}>
-        <CardHeader className="pb-2">
+      <Card className={cn("rounded-xl", className)}>
+        <CardHeader className="!px-3 pt-3 pb-1">
           <div className="flex items-center justify-between">
             <CardTitle className="text-sm font-medium">{metric.name}</CardTitle>
             <Button variant="ghost" size="sm" onClick={onRemove} className="h-6 w-6 p-0">
@@ -40,7 +40,7 @@ export function MetricChart({ metric, values, onHover, onRemove, className }: Me
             </Button>
           </div>
         </CardHeader>
-        <CardContent className="pt-0">
+        <CardContent className="!px-3 pt-0 pb-2">
           <div className="text-sm text-muted-foreground">No data available</div>
         </CardContent>
       </Card>
@@ -71,17 +71,17 @@ export function MetricChart({ metric, values, onHover, onRemove, className }: Me
     (metric.ref_max == null || latestValue <= metric.ref_max);
 
   return (
-    <Card className={cn("rounded-2xl", className)}>
-      <CardHeader className="pb-2">
+    <Card className={cn("rounded-xl", className)}>
+      <CardHeader className="!px-3 pt-3 pb-1">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-medium">{metric.name}</CardTitle>
-            <Badge 
-              variant="secondary" 
+            <Badge
+              variant="secondary"
               className={cn(
                 "text-xs",
-                inRange 
-                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300" 
+                inRange
+                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300"
                   : "bg-rose-100 text-rose-700 dark:bg-rose-900/20 dark:text-rose-300"
               )}
             >
@@ -93,8 +93,8 @@ export function MetricChart({ metric, values, onHover, onRemove, className }: Me
           </Button>
         </div>
       </CardHeader>
-      <CardContent className="pt-0">
-        <div className="h-48 w-full">
+      <CardContent className="!px-3 pt-0 pb-2">
+        <div className="h-52 w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={chartData}


### PR DESCRIPTION
## Summary

Major UI improvements to maximize chart visibility and fix duplicate metric issues.

## Changes

### Metric Deduplication
- ✅ Automatically merges metrics with different capitalizations (e.g., "SEDİMENTASYON" vs "Sedimentasyon")
- ✅ Uses Turkish character normalization to group duplicates
- ✅ Combines all values from duplicate metrics under canonical name

### Dashboard Compression
- ✅ Reduced header padding: 12px → 8px (33% smaller)
- ✅ Reduced main layout padding by 25-40%
- ✅ Reduced section spacing: 24px → 12px
- ✅ Compressed control buttons from 32px to 28px height
- ✅ Made all inputs and selects more compact

### Metric Grid Improvements
- ✅ Grid height: 320px → 192px (shows ~2.5 rows instead of 4)
- ✅ Card padding: 8px → 6px horizontal, 2px vertical
- ✅ Reduced gaps between cards: 16px → 8px
- ✅ Added visual separation for metric names (improved readability)
- ✅ Removed 24px content padding for tighter layout

### Chart Improvements
- ✅ **Removed confusing metric chips** - users close charts via X button directly
- ✅ Chart padding: 24px → 12px (50% reduction)
- ✅ Chart height: 192px → 208px (better label visibility)
- ✅ Tighter header spacing for cleaner look

## Result

The dashboard now fits significantly more content above the fold, giving users:
- Better chart visibility with less scrolling
- Cleaner, more professional appearance
- No duplicate metrics confusion
- More space for the actual data visualization

## Testing

Tested with various screen sizes and metric combinations to ensure readability is maintained while maximizing information density.

🤖 Generated with [Claude Code](https://claude.com/claude-code)