### PR TITLE
refactor: metric_definitions → metric_preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ QSTASH_NEXT_SIGNING_KEY=your-next-signing-key
 - **profiles**: Family member profiles
 - **reports**: Blood test reports with sample dates
 - **metrics**: Individual test values (Hemoglobin, etc.)
-- **metric_definitions**: Reference ranges per profile
+- **metric_preferences**: Display order and favorites per profile
 - **processed_files**: Upload tracking (prevents duplicates)
 - **pending_uploads**: In-progress upload state
 

--- a/db-schema/migrations/20260211_metric_preferences.sql
+++ b/db-schema/migrations/20260211_metric_preferences.sql
@@ -1,0 +1,19 @@
+-- Rename metric_definitions → metric_preferences
+-- Drop unit, ref_low, ref_high columns (refs live in metrics table per reading)
+-- Keep only display_order, is_favorite (actual preferences)
+
+BEGIN;
+
+-- Rename the table
+ALTER TABLE metric_definitions RENAME TO metric_preferences;
+
+-- Drop columns that don't belong in preferences
+ALTER TABLE metric_preferences DROP COLUMN IF EXISTS unit;
+ALTER TABLE metric_preferences DROP COLUMN IF EXISTS ref_low;
+ALTER TABLE metric_preferences DROP COLUMN IF EXISTS ref_high;
+
+-- Rename indexes to match new table name
+ALTER INDEX IF EXISTS idx_metric_definitions_profile RENAME TO idx_metric_preferences_profile;
+ALTER INDEX IF EXISTS idx_metric_definitions_profile_order RENAME TO idx_metric_preferences_profile_order;
+
+COMMIT;

--- a/db-schema/schema.md
+++ b/db-schema/schema.md
@@ -53,14 +53,11 @@ This document describes the Supabase database schema for ViziAI, a blood test tr
          ▼ (via profile_id)
 
 ┌─────────────────────────┐
-│   metric_definitions    │
+│   metric_preferences    │
 ├─────────────────────────┤
 │ id (UUID) PK            │
 │ profile_id FK           │───► profiles
 │ name                    │
-│ unit                    │
-│ ref_low                 │
-│ ref_high                │
 │ display_order           │
 │ is_favorite             │
 │ created_at              │
@@ -135,30 +132,21 @@ Individual test values with reference ranges. Belongs to a report.
 
 **Constraint:** Unique on (report_id, name)
 
-### metric_definitions
+### metric_preferences
 
-Canonical metric metadata: reference values, display order, favorites. Separates metric configuration from individual test values.
+Per-profile user preferences for metric display. Reference ranges live in the `metrics` table (per reading).
 
 | Column          | Type        | Description                                  |
 | --------------- | ----------- | -------------------------------------------- |
 | `id`            | UUID        | Primary key                                  |
 | `profile_id`    | UUID        | FK to profiles                               |
 | `name`          | TEXT        | Metric name (e.g., "Hemoglobin")             |
-| `unit`          | TEXT        | Unit of measurement (e.g., "g/dL")           |
-| `ref_low`       | NUMERIC     | Canonical reference range low                |
-| `ref_high`      | NUMERIC     | Canonical reference range high               |
 | `display_order` | INTEGER     | Order for display in dashboard (0 = default) |
 | `is_favorite`   | BOOLEAN     | Whether this is a favorite/priority metric   |
-| `created_at`    | TIMESTAMPTZ | When the definition was created              |
+| `created_at`    | TIMESTAMPTZ | When the row was created                     |
 | `updated_at`    | TIMESTAMPTZ | Last update timestamp                        |
 
 **Constraint:** Unique on (profile_id, name)
-
-**Purpose:** Unlike the `metrics` table which stores a reference range for each individual test result (which may vary by lab), `metric_definitions` stores a single canonical reference range per metric per profile. This enables:
-
-- Consistent reference lines on charts
-- User-defined display order
-- Marking favorite metrics
 
 ## Indexes
 
@@ -171,8 +159,8 @@ Canonical metric metadata: reference values, display order, favorites. Separates
 - `idx_metrics_report` - metrics(report_id)
 - `idx_metrics_name` - metrics(name)
 - `idx_metrics_report_name` - metrics(report_id, name)
-- `idx_metric_definitions_profile` - metric_definitions(profile_id)
-- `idx_metric_definitions_profile_order` - metric_definitions(profile_id, display_order)
+- `idx_metric_preferences_profile` - metric_preferences(profile_id)
+- `idx_metric_preferences_profile_order` - metric_preferences(profile_id, display_order)
 
 ## Row Level Security (RLS)
 
@@ -203,10 +191,10 @@ All tables have RLS enabled with the following policies:
 - **All operations:** Editors and owners can manage metrics
 - **Service role:** Full access for server-side operations
 
-### metric_definitions
+### metric_preferences
 
-- **View:** Users can view metric definitions for accessible profiles
-- **All operations:** Editors and owners can manage metric definitions
+- **View:** Users can view metric preferences for accessible profiles
+- **All operations:** Editors and owners can manage metric preferences
 - **Service role:** Full access for server-side operations
 
 ## Data Flow

--- a/web/src/app/api/upload/[id]/confirm/route.ts
+++ b/web/src/app/api/upload/[id]/confirm/route.ts
@@ -201,26 +201,12 @@ export async function POST(
       } else {
         updatedCount++;
       }
-    }
 
-    // Update or create metric_definitions for new metrics (only for valid metrics)
-    for (const metric of body.metrics) {
-      if (!isValidMetricValue(metric.value)) continue;
-
+      // Ensure metric_preferences row exists for display_order tracking
       await sql`
-        INSERT INTO metric_definitions (profile_id, name, unit, ref_low, ref_high)
-        VALUES (
-          ${profileId},
-          ${metric.name},
-          ${metric.unit || null},
-          ${metric.ref_low ?? null},
-          ${metric.ref_high ?? null}
-        )
-        ON CONFLICT (profile_id, name) DO UPDATE
-        SET
-          unit = COALESCE(EXCLUDED.unit, metric_definitions.unit),
-          ref_low = COALESCE(EXCLUDED.ref_low, metric_definitions.ref_low),
-          ref_high = COALESCE(EXCLUDED.ref_high, metric_definitions.ref_high)
+        INSERT INTO metric_preferences (profile_id, name)
+        VALUES (${profileId}, ${metric.name})
+        ON CONFLICT (profile_id, name) DO NOTHING
       `;
     }
 


### PR DESCRIPTION
## Summary

- **Rename** `metric_definitions` → `metric_preferences` (it stores preferences, not definitions)
- **Drop** `unit`, `ref_low`, `ref_high` columns — ref ranges already live in `metrics` table per reading
- **Dashboard** now reads ref ranges from the latest `metrics` row per metric name
- **Upload confirm** just ensures a preferences row exists (no more ref copying)
- **Docs** updated: `schema.md`, `README.md`

## Migration

`db-schema/migrations/20260211_metric_preferences.sql` must be run on Neon **before** deploying:
```sql
ALTER TABLE metric_definitions RENAME TO metric_preferences;
ALTER TABLE metric_preferences DROP COLUMN unit, ref_low, ref_high;
```
Tested on Neon branch — migration clean, UI verified locally.

## Test plan

- [x] Migration tested on Neon `migration-test` branch
- [x] Local dev server against migrated branch — dashboard loads, charts show ref ranges
- [x] `/api/metrics` returns 164 metrics with ref ranges from `metrics` table
- [x] `/api/metric-order` GET/PUT works with renamed table
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)