### PR TITLE
fix: accept comma and period as decimal in weight input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ token_*.json
 .env.neon
 .env.test
 .obsidian/
+.vercel

--- a/web/src/components/add-weight-dialog.tsx
+++ b/web/src/components/add-weight-dialog.tsx
@@ -38,7 +38,7 @@ export function AddWeightDialog({
   const [notes, setNotes] = useState("");
   const [saving, setSaving] = useState(false);
 
-  const weightNum = parseFloat(weight);
+  const weightNum = parseFloat(weight.replace(",", "."));
   const hasValidInput = !isNaN(weightNum) && weightNum > 0;
 
   const recent = recentMeasurements
@@ -111,15 +111,17 @@ export function AddWeightDialog({
                 </Label>
                 <Input
                   id="weight"
-                  type="number"
+                  type="text"
                   inputMode="decimal"
-                  step="0.1"
                   placeholder="82.5"
                   value={weight}
-                  onChange={(e) => setWeight(e.target.value)}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setWeight(v);
+                    }
+                  }}
                   className="h-14 text-2xl font-semibold text-center tabular-nums"
-                  min={1}
-                  max={500}
                   autoFocus
                 />
               </div>


### PR DESCRIPTION
## Summary
- Weight input on mobile opened numeric keyboard but rejected comma as decimal separator (Turkish locale uses comma)
- Changed `type="number"` to `type="text"` with `inputMode="decimal"` so both `.` and `,` work
- Added input regex validation and comma-to-period normalization before parsing

## Test plan
- [ ] Open weight dialog on mobile — numeric keyboard still appears
- [ ] Enter `97.75` with period — accepted and saved correctly
- [ ] Enter `97,75` with comma — accepted and saved correctly
- [ ] Letters and invalid input rejected
- [ ] Trend indicator still shows correct diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)