### PR TITLE
feat: add Playwright e2e tests with CI workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,46 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+      NEXTAUTH_SECRET: e2e-test-secret-not-for-production
+      NEXTAUTH_URL: http://localhost:3000
+      GOOGLE_CLIENT_ID: dummy-client-id
+      GOOGLE_CLIENT_SECRET: dummy-client-secret
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: web
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        working-directory: web
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -81,6 +81,34 @@ QSTASH_NEXT_SIGNING_KEY=your-next-signing-key
 NEXT_PUBLIC_SENTRY_DSN=your-sentry-dsn
 ```
 
+## Testing
+
+### Unit Tests (Jest)
+
+```bash
+cd web
+npm test
+```
+
+### E2E Tests (Playwright)
+
+End-to-end tests run against a real dev server and database. They seed a dummy test user (`e2e-test@viziai.test`), exercise the UI in a real browser, and clean up after themselves.
+
+```bash
+cd web
+npx playwright test          # headless
+npx playwright test --headed # watch it run
+npx playwright show-report   # view HTML report
+```
+
+Requires `.env.local` with `NEON_DATABASE_URL` and `NEXTAUTH_SECRET`.
+
+### CI
+
+E2E tests run automatically on every **pull request to `main`** via GitHub Actions. The workflow installs Chromium, starts the dev server, runs the tests, and uploads the Playwright report as an artifact if anything fails.
+
+The `NEON_DATABASE_URL` secret must be set in GitHub repo settings under Settings > Secrets > Actions.
+
 ## Database Schema
 
 - **profiles**: Family member profiles

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/web/e2e/helpers/auth.ts
+++ b/web/e2e/helpers/auth.ts
@@ -1,0 +1,81 @@
+import { hkdfSync } from "crypto";
+import { EncryptJWT } from "jose";
+import type { Browser, BrowserContext, Page } from "@playwright/test";
+import { TEST_EMAIL, TEST_NAME } from "./db";
+
+/**
+ * Derive the encryption key NextAuth v4 uses for JWE tokens.
+ * Matches: https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/jwt/index.ts
+ */
+function getDerivedEncryptionKey(secret: string): Uint8Array {
+  return new Uint8Array(
+    hkdfSync("sha256", secret, "", "NextAuth.js Generated Encryption Key", 32),
+  );
+}
+
+/**
+ * Create an encrypted JWT cookie value matching NextAuth v4's format.
+ * The middleware's `getToken({ req, secret })` will decrypt and validate this.
+ */
+export async function createSessionCookie(
+  dbId: string,
+  email: string,
+  name: string,
+): Promise<string> {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) throw new Error("NEXTAUTH_SECRET is not set");
+
+  const encryptionKey = getDerivedEncryptionKey(secret);
+  const now = Math.floor(Date.now() / 1000);
+  const maxAge = 30 * 24 * 60 * 60; // 30 days
+
+  // email and name are required — requireAuth() checks session.user.email
+  return new EncryptJWT({
+    sub: dbId,
+    dbId,
+    email,
+    name,
+    jti: crypto.randomUUID(),
+  })
+    .setProtectedHeader({ alg: "dir", enc: "A256GCM" })
+    .setIssuedAt()
+    .setExpirationTime(now + maxAge)
+    .encrypt(encryptionKey);
+}
+
+/**
+ * Create a browser context with auth and profile cookies pre-set,
+ * then open a new page. Call `context.close()` when done.
+ */
+export async function authenticatedContext(
+  browser: Browser,
+  dbId: string,
+  profileId: string,
+): Promise<{ context: BrowserContext; page: Page }> {
+  const token = await createSessionCookie(dbId, TEST_EMAIL, TEST_NAME);
+  const context = await browser.newContext();
+
+  await context.addCookies([
+    {
+      name: "next-auth.session-token",
+      value: token,
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      secure: false,
+      sameSite: "Lax",
+    },
+    {
+      name: "viziai_active_profile",
+      value: profileId,
+      domain: "localhost",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+
+  const page = await context.newPage();
+  return { context, page };
+}

--- a/web/e2e/helpers/db.ts
+++ b/web/e2e/helpers/db.ts
@@ -1,0 +1,71 @@
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.NEON_DATABASE_URL!);
+
+export const TEST_EMAIL = "e2e-test@viziai.test";
+export const TEST_NAME = "E2E Test User";
+const TEST_PROFILE_NAME = "E2E Test Profile";
+
+/**
+ * Seed a test user with a profile and access grant.
+ * Idempotent — safe to call multiple times.
+ */
+export async function seedTestUser(): Promise<{
+  userId: string;
+  profileId: string;
+}> {
+  // Upsert user
+  const [user] = await sql`
+    INSERT INTO users (email, name)
+    VALUES (${TEST_EMAIL}, ${TEST_NAME})
+    ON CONFLICT (email) DO UPDATE SET name = EXCLUDED.name
+    RETURNING id
+  `;
+
+  // Upsert profile
+  const existing = await sql`
+    SELECT id FROM profiles WHERE display_name = ${TEST_PROFILE_NAME}
+  `;
+
+  let profileId: string;
+  if (existing.length > 0) {
+    profileId = existing[0].id;
+  } else {
+    const [profile] = await sql`
+      INSERT INTO profiles (display_name) VALUES (${TEST_PROFILE_NAME})
+      RETURNING id
+    `;
+    profileId = profile.id;
+  }
+
+  // Ensure user has access to the profile
+  await sql`
+    INSERT INTO user_access (user_id_new, profile_id, access_level, granted_by)
+    VALUES (${user.id}, ${profileId}, 'owner', ${user.id})
+    ON CONFLICT (user_id_new, profile_id) DO NOTHING
+  `;
+
+  return { userId: user.id, profileId };
+}
+
+/**
+ * Delete all tracking_measurements for a given profile.
+ */
+export async function cleanupTrackingData(profileId: string): Promise<void> {
+  await sql`
+    DELETE FROM tracking_measurements WHERE profile_id = ${profileId}
+  `;
+}
+
+/**
+ * Full cleanup: remove user, profile, access, and tracking data.
+ */
+export async function deleteTestUser(userId: string): Promise<void> {
+  // Delete in dependency order
+  await sql`DELETE FROM tracking_measurements WHERE profile_id IN (
+    SELECT profile_id FROM user_access WHERE user_id_new = ${userId}
+  )`;
+  await sql`DELETE FROM user_access WHERE user_id_new = ${userId}`;
+  await sql`DELETE FROM profiles WHERE display_name = ${TEST_PROFILE_NAME}`;
+  await sql`DELETE FROM users WHERE id = ${userId}`;
+}

--- a/web/e2e/weight-dialog.spec.ts
+++ b/web/e2e/weight-dialog.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from "@playwright/test";
+import { authenticatedContext } from "./helpers/auth";
+import {
+  seedTestUser,
+  cleanupTrackingData,
+  deleteTestUser,
+} from "./helpers/db";
+
+let userId: string;
+let profileId: string;
+
+test.beforeAll(async () => {
+  const result = await seedTestUser();
+  userId = result.userId;
+  profileId = result.profileId;
+});
+
+test.afterAll(async () => {
+  await deleteTestUser(userId);
+});
+
+test.afterEach(async () => {
+  await cleanupTrackingData(profileId);
+});
+
+test.describe("Weight Dialog", () => {
+  // Tests share DB state — must run serially in one worker
+  test.describe.configure({ mode: "serial" });
+
+  test("opens weight dialog from Ekle menu", async ({ browser }) => {
+    const { context, page } = await authenticatedContext(
+      browser,
+      userId,
+      profileId,
+    );
+
+    await page.goto("/dashboard");
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.locator("#weight")).toBeVisible();
+
+    await context.close();
+  });
+
+  test("accepts comma as decimal separator", async ({ browser }) => {
+    const { context, page } = await authenticatedContext(
+      browser,
+      userId,
+      profileId,
+    );
+
+    await page.goto("/dashboard");
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+
+    await page.locator("#weight").fill("82,5");
+    await expect(page.getByRole("button", { name: "Kaydet" })).toBeEnabled();
+
+    await context.close();
+  });
+
+  test("accepts period as decimal separator", async ({ browser }) => {
+    const { context, page } = await authenticatedContext(
+      browser,
+      userId,
+      profileId,
+    );
+
+    await page.goto("/dashboard");
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+
+    await page.locator("#weight").fill("82.5");
+    await expect(page.getByRole("button", { name: "Kaydet" })).toBeEnabled();
+
+    await context.close();
+  });
+
+  test("saves weight entry", async ({ browser }) => {
+    const { context, page } = await authenticatedContext(
+      browser,
+      userId,
+      profileId,
+    );
+
+    await page.goto("/dashboard");
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+
+    await page.locator("#weight").fill("75.5");
+    await page.getByRole("button", { name: "Kaydet" }).click();
+
+    await expect(page.getByText("Kilo kaydedildi")).toBeVisible();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+
+    await context.close();
+  });
+
+  test("shows replace confirmation for same-day entry", async ({ browser }) => {
+    const { context, page } = await authenticatedContext(
+      browser,
+      userId,
+      profileId,
+    );
+
+    await page.goto("/dashboard");
+
+    // First entry
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+    await page.locator("#weight").fill("75.5");
+    await page.getByRole("button", { name: "Kaydet" }).click();
+    await expect(page.getByText("Kilo kaydedildi")).toBeVisible();
+
+    // Second entry — same day
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+    await page.locator("#weight").fill("76.0");
+    await page.getByRole("button", { name: "Kaydet" }).click();
+
+    await expect(page.getByText("Bugün zaten kayıt var")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Değiştir" })).toBeVisible();
+
+    await context.close();
+  });
+
+  test("replaces existing entry", async ({ browser }) => {
+    const { context, page } = await authenticatedContext(
+      browser,
+      userId,
+      profileId,
+    );
+
+    await page.goto("/dashboard");
+
+    // First entry
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+    await page.locator("#weight").fill("75.5");
+    await page.getByRole("button", { name: "Kaydet" }).click();
+    await expect(page.getByText("Kilo kaydedildi")).toBeVisible();
+
+    // Second entry — triggers conflict
+    await page.getByRole("button", { name: /Ekle/ }).click();
+    await page.getByText("Kilo Ekle").click();
+    await page.locator("#weight").fill("76.0");
+    await page.getByRole("button", { name: "Kaydet" }).click();
+    await expect(page.getByText("Bugün zaten kayıt var")).toBeVisible();
+
+    // Replace
+    await page.getByRole("button", { name: "Değiştir" }).click();
+    await expect(page.getByText("Kilo kaydedildi")).toBeVisible();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+
+    await context.close();
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -40,6 +40,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
@@ -48,10 +49,12 @@
         "@types/pdf-parse": "^1.1.5",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "15.5.3",
         "jest": "^30.1.3",
         "jest-environment-jsdom": "^30.1.2",
+        "jose": "^6.1.3",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.8",
         "typescript": "^5"
@@ -2937,6 +2940,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@prisma/instrumentation": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.2.0.tgz",
@@ -5022,6 +5041,18 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
@@ -8427,9 +8458,10 @@
       "peer": true
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -11754,9 +11786,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -12648,6 +12681,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/next-auth/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -12948,6 +12990,15 @@
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -13280,6 +13331,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
@@ -52,10 +54,12 @@
     "@types/pdf-parse": "^1.1.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
     "jest": "^30.1.3",
     "jest-environment-jsdom": "^30.1.2",
+    "jose": "^6.1.3",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+import path from "path";
+
+// Load .env.local so test helpers can access NEON_DATABASE_URL and NEXTAUTH_SECRET
+dotenv.config({ path: path.resolve(__dirname, ".env.local") });
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- Playwright setup with auth bypassing Google OAuth (encrypted JWT matching NextAuth v4)
- 6 weight dialog tests: open, comma/period input, save, replace confirmation, replace
- GitHub Actions workflow runs automatically on PRs to main
- README updated with testing docs

## Test plan
- [x] All 6 tests pass locally (`cd web && npx playwright test`)
- [x] `npm run build` passes
- [ ] CI workflow runs on this PR and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)