### PR TITLE
feat: add tracking history tabs to settings page

### DIFF
--- a/web/src/app/api/tracking/[id]/route.ts
+++ b/web/src/app/api/tracking/[id]/route.ts
@@ -1,17 +1,40 @@
 import { NextResponse } from "next/server";
 import { sql } from "@/lib/db";
-import { requireAuth, hasProfileAccess } from "@/lib/auth";
+import { requireAuth, getProfileAccessLevel } from "@/lib/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/**
- * DELETE /api/tracking/[id]
- */
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
+type RouteContext = { params: Promise<{ id: string }> };
+
+async function getMeasurementAndCheckAccess(
+  userId: string,
+  id: string,
+  requiredLevels: string[],
 ) {
+  const rows = await sql`
+    SELECT profile_id, type FROM tracking_measurements WHERE id = ${id}
+  `;
+  if (rows.length === 0) {
+    return {
+      error: NextResponse.json(
+        { error: "Measurement not found" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  const level = await getProfileAccessLevel(userId, rows[0].profile_id);
+  if (!level || !requiredLevels.includes(level)) {
+    return {
+      error: NextResponse.json({ error: "Access denied" }, { status: 403 }),
+    };
+  }
+
+  return { measurement: rows[0], level };
+}
+
+export async function PUT(request: Request, { params }: RouteContext) {
   try {
     const userId = await requireAuth();
     if (!userId) {
@@ -19,23 +42,94 @@ export async function DELETE(
     }
 
     const { id } = await params;
+    const result = await getMeasurementAndCheckAccess(userId, id, [
+      "owner",
+      "editor",
+    ]);
+    if (result.error) return result.error;
 
-    // Get measurement to check profile access
-    const measurement = await sql`
-      SELECT profile_id FROM tracking_measurements WHERE id = ${id}
+    const body = await request.json();
+    const { weightKg, systolic, diastolic, pulse } = body;
+    const notesRaw = body.notes;
+    const notes = typeof notesRaw === "string" ? notesRaw.slice(0, 500) : null;
+    const { type } = result.measurement!;
+
+    if (type === "weight") {
+      if (weightKg == null) {
+        return NextResponse.json(
+          { error: "weightKg is required" },
+          { status: 400 },
+        );
+      }
+      if (weightKg < 1 || weightKg > 500) {
+        return NextResponse.json(
+          { error: "Weight value out of valid range" },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (type === "blood_pressure") {
+      if (systolic == null || diastolic == null) {
+        return NextResponse.json(
+          { error: "systolic and diastolic are required" },
+          { status: 400 },
+        );
+      }
+      if (
+        systolic < 50 ||
+        systolic > 300 ||
+        diastolic < 20 ||
+        diastolic > 200
+      ) {
+        return NextResponse.json(
+          { error: "Blood pressure values out of valid range" },
+          { status: 400 },
+        );
+      }
+      if (pulse != null && (pulse < 20 || pulse > 250)) {
+        return NextResponse.json(
+          { error: "Pulse value out of valid range" },
+          { status: 400 },
+        );
+      }
+    }
+
+    const updated = await sql`
+      UPDATE tracking_measurements
+      SET
+        weight_kg = ${type === "weight" ? weightKg : null},
+        systolic = ${type === "blood_pressure" ? systolic : null},
+        diastolic = ${type === "blood_pressure" ? diastolic : null},
+        pulse = ${type === "blood_pressure" ? (pulse ?? null) : null},
+        notes = ${notes ?? null}
+      WHERE id = ${id}
+      RETURNING id, profile_id, type, measured_at, systolic, diastolic, pulse, weight_kg, notes, created_at
     `;
 
-    if (measurement.length === 0) {
-      return NextResponse.json(
-        { error: "Measurement not found" },
-        { status: 404 },
-      );
+    return NextResponse.json({ measurement: updated[0] });
+  } catch (error) {
+    console.error("/api/tracking/[id] PUT error:", error);
+    return NextResponse.json(
+      { error: "Failed to update measurement" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  try {
+    const userId = await requireAuth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const hasAccess = await hasProfileAccess(userId, measurement[0].profile_id);
-    if (!hasAccess) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
-    }
+    const { id } = await params;
+    const result = await getMeasurementAndCheckAccess(userId, id, [
+      "owner",
+      "editor",
+    ]);
+    if (result.error) return result.error;
 
     await sql`DELETE FROM tracking_measurements WHERE id = ${id}`;
 

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowDown,
   ArrowUp,
@@ -11,9 +12,18 @@ import {
   Loader2,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { TrackingHistory } from "@/components/tracking-history";
 import { useActiveProfile } from "@/hooks/use-active-profile";
 import { formatDateTR, formatDateTimeTR } from "@/lib/date";
 import { reportError } from "@/lib/error-reporting";
+
+type Tab = "tahliller" | "kilo" | "tansiyon";
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: "tahliller", label: "Tahliller" },
+  { key: "kilo", label: "Kilo" },
+  { key: "tansiyon", label: "Tansiyon" },
+];
 
 type SortColumn = "sample_date" | "created_at";
 type SortDirection = "asc" | "desc";
@@ -27,10 +37,38 @@ interface ProcessedFile {
 }
 
 export default function SettingsPage() {
-  const { activeProfileId } = useActiveProfile();
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <SettingsContent />
+    </Suspense>
+  );
+}
+
+function SettingsContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { activeProfile, activeProfileId } = useActiveProfile();
+
+  const tabParam = searchParams.get("tab") as Tab | null;
+  const activeTab: Tab =
+    tabParam && TABS.some((t) => t.key === tabParam) ? tabParam : "tahliller";
+
+  function setActiveTab(tab: Tab) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", tab);
+    router.replace(`/settings?${params.toString()}`, { scroll: false });
+  }
+
   const [files, setFiles] = useState<ProcessedFile[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [filesLoading, setFilesLoading] = useState(false);
+  const [filesError, setFilesError] = useState<string | null>(null);
+  const [filesFetched, setFilesFetched] = useState(false);
   const [sortColumn, setSortColumn] = useState<SortColumn>("sample_date");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
 
@@ -39,7 +77,6 @@ export default function SettingsPage() {
       const aValue = a[sortColumn];
       const bValue = b[sortColumn];
 
-      // Handle null values - push them to the end
       if (!aValue && !bValue) return 0;
       if (!aValue) return 1;
       if (!bValue) return -1;
@@ -50,14 +87,14 @@ export default function SettingsPage() {
     });
   }, [files, sortColumn, sortDirection]);
 
-  const handleSort = (column: SortColumn) => {
+  function handleSort(column: SortColumn) {
     if (sortColumn === column) {
       setSortDirection(sortDirection === "asc" ? "desc" : "asc");
     } else {
       setSortColumn(column);
       setSortDirection("desc");
     }
-  };
+  }
 
   function SortIcon({ column }: { column: SortColumn }): React.ReactElement {
     if (sortColumn !== column) {
@@ -109,11 +146,11 @@ export default function SettingsPage() {
   }
 
   useEffect(() => {
-    async function fetchFiles() {
-      if (!activeProfileId) return;
+    if (activeTab !== "tahliller" || !activeProfileId || filesFetched) return;
 
+    async function fetchFiles() {
       try {
-        setLoading(true);
+        setFilesLoading(true);
         const response = await fetch(
           `/api/settings/files?profileId=${activeProfileId}`,
         );
@@ -124,181 +161,215 @@ export default function SettingsPage() {
 
         const data = await response.json();
         setFiles(data.files || []);
+        setFilesFetched(true);
       } catch (err) {
         reportError(err, {
           op: "settings.fetchFiles",
           profileId: activeProfileId,
         });
-        setError("Dosyalar yüklenirken bir hata oluştu");
+        setFilesError("Dosyalar yüklenirken bir hata oluştu");
       } finally {
-        setLoading(false);
+        setFilesLoading(false);
       }
     }
 
     fetchFiles();
-  }, [activeProfileId]);
+  }, [activeProfileId, activeTab, filesFetched]);
+
+  const accessLevel = activeProfile?.access_level ?? null;
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">Dosyalar</h1>
+      {/* Tab bar */}
+      <div className="flex gap-2">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={`text-sm px-3 py-1.5 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              activeTab === tab.key
+                ? "bg-primary text-primary-foreground border-primary"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <FileText aria-hidden="true" className="h-5 w-5" />
-            Yüklenen Dosyalar
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {loading ? (
-            <div
-              className="flex items-center justify-center py-8"
-              role="status"
-              aria-live="polite"
-            >
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              <span className="sr-only">Yükleniyor…</span>
-            </div>
-          ) : error ? (
-            <p className="text-sm text-status-critical py-4">{error}</p>
-          ) : files.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4">
-              Henüz yüklenmiş dosya yok.
-            </p>
-          ) : (
-            <>
-              {/* Desktop table view */}
-              <div className="hidden md:block border rounded-lg overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead className="bg-muted">
-                    <tr>
-                      <th className="text-left p-3 font-medium">Dosya Adı</th>
-                      <SortableHeader
-                        column="sample_date"
-                        label="Tahlil Tarihi"
-                      />
-                      <SortableHeader column="created_at" label="Yüklenme" />
-                      <th className="text-center p-3 font-medium">Metrik</th>
-                      <th className="text-right p-3 font-medium">
-                        <span className="sr-only">İşlemler</span>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedFiles.map((file) => (
-                      <tr key={file.id} className="border-t hover:bg-muted/50">
-                        <td className="p-3 max-w-[200px]">
-                          <span
-                            className="font-medium truncate block"
+      {activeTab === "tahliller" && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <FileText aria-hidden="true" className="h-5 w-5" />
+              Yüklenen Dosyalar
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {filesLoading ? (
+              <div
+                className="flex items-center justify-center py-8"
+                role="status"
+                aria-live="polite"
+              >
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                <span className="sr-only">Yükleniyor…</span>
+              </div>
+            ) : filesError ? (
+              <p className="text-sm text-status-critical py-4">{filesError}</p>
+            ) : files.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4">
+                Henüz yüklenmiş dosya yok.
+              </p>
+            ) : (
+              <>
+                {/* Desktop table view */}
+                <div className="hidden md:block border rounded-lg overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead className="bg-muted">
+                      <tr>
+                        <th className="text-left p-3 font-medium">Dosya Adı</th>
+                        <SortableHeader
+                          column="sample_date"
+                          label="Tahlil Tarihi"
+                        />
+                        <SortableHeader column="created_at" label="Yüklenme" />
+                        <th className="text-center p-3 font-medium">Metrik</th>
+                        <th className="text-right p-3 font-medium">
+                          <span className="sr-only">İşlemler</span>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedFiles.map((file) => (
+                        <tr
+                          key={file.id}
+                          className="border-t hover:bg-muted/50"
+                        >
+                          <td className="p-3 max-w-[200px]">
+                            <span
+                              className="font-medium truncate block"
+                              title={file.file_name}
+                            >
+                              {file.file_name}
+                            </span>
+                          </td>
+                          <td className="p-3">
+                            {file.sample_date ? (
+                              <span className="font-medium">
+                                {formatDateTR(file.sample_date)}
+                              </span>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </td>
+                          <td className="p-3 text-muted-foreground">
+                            {formatDateTimeTR(file.created_at)}
+                          </td>
+                          <td className="p-3 text-center">
+                            <span className="inline-flex items-center justify-center min-w-[2rem] px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs font-medium tabular-nums">
+                              {file.metric_count}
+                            </span>
+                          </td>
+                          <td className="p-3 text-right">
+                            <Link
+                              href={`/settings/files/${file.id}`}
+                              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium border rounded-md hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            >
+                              Değerleri Gör
+                              <ChevronRight
+                                aria-hidden="true"
+                                className="h-4 w-4"
+                              />
+                            </Link>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Mobile card view */}
+                <div className="md:hidden space-y-3">
+                  <div className="flex gap-2 mb-2">
+                    <button
+                      type="button"
+                      onClick={() => handleSort("sample_date")}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                        sortColumn === "sample_date"
+                          ? "bg-primary text-primary-foreground border-primary"
+                          : "text-muted-foreground hover:text-foreground"
+                      }`}
+                    >
+                      Tahlil Tarihi{" "}
+                      {sortColumn === "sample_date" &&
+                        (sortDirection === "desc" ? "↓" : "↑")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleSort("created_at")}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                        sortColumn === "created_at"
+                          ? "bg-primary text-primary-foreground border-primary"
+                          : "text-muted-foreground hover:text-foreground"
+                      }`}
+                    >
+                      Yüklenme{" "}
+                      {sortColumn === "created_at" &&
+                        (sortDirection === "desc" ? "↓" : "↑")}
+                    </button>
+                  </div>
+                  {sortedFiles.map((file) => (
+                    <Link
+                      key={file.id}
+                      href={`/settings/files/${file.id}`}
+                      className="flex items-center gap-3 border rounded-lg p-3 hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2">
+                          <p
+                            className="font-medium text-sm truncate"
                             title={file.file_name}
                           >
                             {file.file_name}
-                          </span>
-                        </td>
-                        <td className="p-3">
-                          {file.sample_date ? (
-                            <span className="font-medium">
-                              {formatDateTR(file.sample_date)}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </td>
-                        <td className="p-3 text-muted-foreground">
-                          {formatDateTimeTR(file.created_at)}
-                        </td>
-                        <td className="p-3 text-center">
-                          <span className="inline-flex items-center justify-center min-w-[2rem] px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs font-medium tabular-nums">
+                          </p>
+                          <span className="inline-flex items-center justify-center min-w-[2rem] px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs font-medium tabular-nums shrink-0">
                             {file.metric_count}
                           </span>
-                        </td>
-                        <td className="p-3 text-right">
-                          <Link
-                            href={`/settings/files/${file.id}`}
-                            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium border rounded-md hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                          >
-                            Değerleri Gör
-                            <ChevronRight
-                              aria-hidden="true"
-                              className="h-4 w-4"
-                            />
-                          </Link>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-
-              {/* Mobile card view */}
-              <div className="md:hidden space-y-3">
-                <div className="flex gap-2 mb-2">
-                  <button
-                    type="button"
-                    onClick={() => handleSort("sample_date")}
-                    className={`text-xs px-2.5 py-1 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-                      sortColumn === "sample_date"
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "text-muted-foreground hover:text-foreground"
-                    }`}
-                  >
-                    Tahlil Tarihi{" "}
-                    {sortColumn === "sample_date" &&
-                      (sortDirection === "desc" ? "↓" : "↑")}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleSort("created_at")}
-                    className={`text-xs px-2.5 py-1 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-                      sortColumn === "created_at"
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "text-muted-foreground hover:text-foreground"
-                    }`}
-                  >
-                    Yüklenme{" "}
-                    {sortColumn === "created_at" &&
-                      (sortDirection === "desc" ? "↓" : "↑")}
-                  </button>
+                        </div>
+                        <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
+                          {file.sample_date ? (
+                            <span>
+                              Tahlil: {formatDateTR(file.sample_date)}
+                            </span>
+                          ) : (
+                            <span>Tahlil tarihi yok</span>
+                          )}
+                          <span>·</span>
+                          <span>{formatDateTimeTR(file.created_at)}</span>
+                        </div>
+                      </div>
+                      <ChevronRight
+                        aria-hidden="true"
+                        className="h-4 w-4 text-muted-foreground shrink-0"
+                      />
+                    </Link>
+                  ))}
                 </div>
-                {sortedFiles.map((file) => (
-                  <Link
-                    key={file.id}
-                    href={`/settings/files/${file.id}`}
-                    className="flex items-center gap-3 border rounded-lg p-3 hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-start justify-between gap-2">
-                        <p
-                          className="font-medium text-sm truncate"
-                          title={file.file_name}
-                        >
-                          {file.file_name}
-                        </p>
-                        <span className="inline-flex items-center justify-center min-w-[2rem] px-2 py-0.5 bg-primary/10 text-primary rounded-full text-xs font-medium tabular-nums shrink-0">
-                          {file.metric_count}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
-                        {file.sample_date ? (
-                          <span>Tahlil: {formatDateTR(file.sample_date)}</span>
-                        ) : (
-                          <span>Tahlil tarihi yok</span>
-                        )}
-                        <span>·</span>
-                        <span>{formatDateTimeTR(file.created_at)}</span>
-                      </div>
-                    </div>
-                    <ChevronRight
-                      aria-hidden="true"
-                      className="h-4 w-4 text-muted-foreground shrink-0"
-                    />
-                  </Link>
-                ))}
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {activeTab === "kilo" && (
+        <TrackingHistory type="weight" accessLevel={accessLevel} />
+      )}
+
+      {activeTab === "tansiyon" && (
+        <TrackingHistory type="blood_pressure" accessLevel={accessLevel} />
+      )}
     </div>
   );
 }

--- a/web/src/components/tracking-history.tsx
+++ b/web/src/components/tracking-history.tsx
@@ -1,0 +1,732 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Loader2, Pencil, Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast";
+import { useActiveProfile } from "@/hooks/use-active-profile";
+import { formatDateTR } from "@/lib/date";
+import { reportError } from "@/lib/error-reporting";
+import type { TrackingMeasurement } from "@/lib/tracking";
+import { getBPStatus } from "@/lib/tracking";
+import { cn } from "@/lib/utils";
+
+interface TrackingHistoryProps {
+  type: "weight" | "blood_pressure";
+  accessLevel: string | null;
+}
+
+export function TrackingHistory({ type, accessLevel }: TrackingHistoryProps) {
+  const { activeProfileId } = useActiveProfile();
+  const { addToast } = useToast();
+
+  const [measurements, setMeasurements] = useState<TrackingMeasurement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState({
+    weightKg: "",
+    systolic: "",
+    diastolic: "",
+    pulse: "",
+    notes: "",
+  });
+  const [saving, setSaving] = useState(false);
+
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const canEdit = accessLevel === "owner" || accessLevel === "editor";
+
+  useEffect(() => {
+    async function fetchMeasurements() {
+      if (!activeProfileId) return;
+
+      try {
+        setLoading(true);
+        const res = await fetch(
+          `/api/tracking?profileId=${activeProfileId}&type=${type}&limit=200`,
+        );
+        if (!res.ok) throw new Error("Veriler yüklenemedi");
+        const data = await res.json();
+        setMeasurements(data.measurements || []);
+      } catch (err) {
+        reportError(err, { op: "trackingHistory.fetch", type });
+        setError("Veriler yüklenirken bir hata oluştu");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchMeasurements();
+  }, [activeProfileId, type]);
+
+  function startEditing(m: TrackingMeasurement) {
+    setEditingId(m.id);
+    setEditForm({
+      weightKg: m.weight_kg != null ? String(m.weight_kg) : "",
+      systolic: m.systolic != null ? String(m.systolic) : "",
+      diastolic: m.diastolic != null ? String(m.diastolic) : "",
+      pulse: m.pulse != null ? String(m.pulse) : "",
+      notes: m.notes ?? "",
+    });
+  }
+
+  function cancelEditing() {
+    setEditingId(null);
+  }
+
+  async function saveEdit(id: string) {
+    if (type === "weight") {
+      const v = parseFloat(editForm.weightKg);
+      if (!editForm.weightKg.trim() || isNaN(v) || v < 1 || v > 500) {
+        addToast({
+          message: "Geçerli bir kilo değeri girin (1-500)",
+          type: "error",
+        });
+        return;
+      }
+    }
+    if (type === "blood_pressure") {
+      const s = parseFloat(editForm.systolic);
+      const d = parseFloat(editForm.diastolic);
+      if (isNaN(s) || s < 50 || s > 300 || isNaN(d) || d < 20 || d > 200) {
+        addToast({
+          message: "Geçerli tansiyon değerleri girin",
+          type: "error",
+        });
+        return;
+      }
+      if (editForm.pulse.trim()) {
+        const p = parseFloat(editForm.pulse);
+        if (isNaN(p) || p < 20 || p > 250) {
+          addToast({
+            message: "Geçerli bir nabız değeri girin (20-250)",
+            type: "error",
+          });
+          return;
+        }
+      }
+    }
+
+    setSaving(true);
+    try {
+      const body: Record<string, unknown> = {
+        notes: editForm.notes || null,
+      };
+      if (type === "weight") {
+        body.weightKg = parseFloat(editForm.weightKg);
+      } else {
+        body.systolic = parseFloat(editForm.systolic);
+        body.diastolic = parseFloat(editForm.diastolic);
+        body.pulse = editForm.pulse.trim() ? parseFloat(editForm.pulse) : null;
+      }
+
+      const res = await fetch(`/api/tracking/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) throw new Error("Kaydetme başarısız");
+
+      const data = await res.json();
+      setMeasurements((prev) =>
+        prev.map((m) => (m.id === id ? data.measurement : m)),
+      );
+      setEditingId(null);
+      addToast({ message: "Güncellendi", type: "success" });
+    } catch (err) {
+      reportError(err, { op: "trackingHistory.save", id });
+      addToast({ message: "Kaydetme başarısız", type: "error" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function confirmDelete(id: string) {
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/tracking/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Silme başarısız");
+
+      setMeasurements((prev) => prev.filter((m) => m.id !== id));
+      setDeletingId(null);
+      addToast({ message: "Kayıt silindi", type: "success" });
+    } catch (err) {
+      reportError(err, { op: "trackingHistory.delete", id });
+      addToast({ message: "Silme başarısız", type: "error" });
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  function updateField(field: keyof typeof editForm) {
+    return (e: React.ChangeEvent<HTMLInputElement>) =>
+      setEditForm((prev) => ({ ...prev, [field]: e.target.value }));
+  }
+
+  // --- Shared sub-components to reduce duplication across weight/BP layouts ---
+
+  function DeleteConfirm({ id }: { id: string }) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-status-critical">Sil?</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 text-status-critical hover:text-status-critical"
+          onClick={() => confirmDelete(id)}
+          disabled={deleting}
+        >
+          {deleting && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+          Onayla
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7"
+          onClick={() => setDeletingId(null)}
+        >
+          İptal
+        </Button>
+      </div>
+    );
+  }
+
+  function EditDeleteActions({
+    measurement,
+    iconSize = "h-3.5 w-3.5",
+    buttonSize = "h-8 w-8",
+  }: {
+    measurement: TrackingMeasurement;
+    iconSize?: string;
+    buttonSize?: string;
+  }) {
+    return (
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className={buttonSize}
+          onClick={() => startEditing(measurement)}
+          aria-label="Düzenle"
+        >
+          <Pencil className={iconSize} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            buttonSize,
+            "text-muted-foreground hover:text-status-critical",
+          )}
+          onClick={() => setDeletingId(measurement.id)}
+          aria-label="Sil"
+        >
+          <Trash2 className={iconSize} />
+        </Button>
+      </div>
+    );
+  }
+
+  function SaveCancelIcons({ id }: { id: string }) {
+    return (
+      <div className="flex items-center gap-1 justify-end">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => saveEdit(id)}
+          disabled={saving}
+          aria-label="Kaydet"
+        >
+          {saving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Check className="h-4 w-4 text-status-normal" />
+          )}
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={cancelEditing}
+          aria-label="İptal"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    );
+  }
+
+  function MobileSaveCancelButtons({ id }: { id: string }) {
+    return (
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          onClick={() => saveEdit(id)}
+          disabled={saving}
+          className="flex-1"
+        >
+          {saving ? (
+            <Loader2 className="h-4 w-4 animate-spin mr-1.5" />
+          ) : (
+            <Check aria-hidden="true" className="h-4 w-4 mr-1.5" />
+          )}
+          Kaydet
+        </Button>
+        <Button variant="outline" size="sm" onClick={cancelEditing}>
+          İptal
+        </Button>
+      </div>
+    );
+  }
+
+  function NotesInput({ className }: { className?: string }) {
+    return (
+      <Input
+        value={editForm.notes}
+        onChange={updateField("notes")}
+        className={cn("h-8 text-sm", className)}
+        placeholder="—"
+        aria-label="Not"
+      />
+    );
+  }
+
+  // --- Loading / error / empty states ---
+
+  if (loading) {
+    return (
+      <div
+        className="flex items-center justify-center py-8"
+        role="status"
+        aria-live="polite"
+      >
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <span className="sr-only">Yükleniyor…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-status-critical py-4">{error}</p>;
+  }
+
+  if (measurements.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4">Henüz kayıt yok.</p>
+    );
+  }
+
+  // --- Weight ---
+
+  if (type === "weight") {
+    return (
+      <>
+        {/* Desktop */}
+        <div className="hidden md:block border rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted">
+              <tr>
+                <th className="text-left p-3 font-medium">Tarih</th>
+                <th className="text-right p-3 font-medium">Kilo (kg)</th>
+                <th className="text-left p-3 font-medium">Not</th>
+                {canEdit && (
+                  <th className="text-right p-3 font-medium">
+                    <span className="sr-only">İşlemler</span>
+                  </th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {measurements.map((m) => {
+                const isEditing = editingId === m.id;
+                const isDeleting = deletingId === m.id;
+
+                return (
+                  <tr key={m.id} className="border-t hover:bg-muted/50">
+                    {isEditing ? (
+                      <>
+                        <td className="p-3 text-muted-foreground">
+                          {formatDateTR(m.measured_at)}
+                        </td>
+                        <td className="p-2">
+                          <Input
+                            type="number"
+                            step="0.1"
+                            value={editForm.weightKg}
+                            onChange={updateField("weightKg")}
+                            className="h-8 text-sm text-right w-24 ml-auto"
+                            aria-label="Kilo"
+                          />
+                        </td>
+                        <td className="p-2">
+                          <NotesInput className="w-full" />
+                        </td>
+                        <td className="p-2">
+                          <SaveCancelIcons id={m.id} />
+                        </td>
+                      </>
+                    ) : (
+                      <>
+                        <td className="p-3">{formatDateTR(m.measured_at)}</td>
+                        <td className="p-3 text-right tabular-nums font-medium">
+                          {m.weight_kg}
+                        </td>
+                        <td className="p-3 text-muted-foreground truncate max-w-[200px]">
+                          {m.notes || "—"}
+                        </td>
+                        {canEdit && (
+                          <td className="p-3 text-right">
+                            {isDeleting ? (
+                              <div className="flex justify-end">
+                                <DeleteConfirm id={m.id} />
+                              </div>
+                            ) : (
+                              <div className="flex justify-end">
+                                <EditDeleteActions measurement={m} />
+                              </div>
+                            )}
+                          </td>
+                        )}
+                      </>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Mobile */}
+        <div className="md:hidden space-y-2">
+          {measurements.map((m) => {
+            const isEditing = editingId === m.id;
+            const isDeleting = deletingId === m.id;
+
+            return (
+              <div key={m.id} className="border rounded-lg p-3">
+                {isEditing ? (
+                  <div className="space-y-3">
+                    <p className="text-xs text-muted-foreground">
+                      {formatDateTR(m.measured_at)}
+                    </p>
+                    <div className="space-y-2">
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Kilo (kg)
+                        </label>
+                        <Input
+                          type="number"
+                          step="0.1"
+                          value={editForm.weightKg}
+                          onChange={updateField("weightKg")}
+                          className="h-8 text-sm"
+                          aria-label="Kilo"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Not
+                        </label>
+                        <NotesInput />
+                      </div>
+                    </div>
+                    <MobileSaveCancelButtons id={m.id} />
+                  </div>
+                ) : (
+                  <div>
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs text-muted-foreground">
+                        {formatDateTR(m.measured_at)}
+                      </span>
+                      {canEdit && !isDeleting && (
+                        <EditDeleteActions
+                          measurement={m}
+                          iconSize="h-3 w-3"
+                          buttonSize="h-7 w-7"
+                        />
+                      )}
+                    </div>
+                    <p className="text-lg tabular-nums font-medium mt-1">
+                      {m.weight_kg}{" "}
+                      <span className="text-sm text-muted-foreground font-normal">
+                        kg
+                      </span>
+                    </p>
+                    {m.notes && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {m.notes}
+                      </p>
+                    )}
+                    {isDeleting && (
+                      <div className="mt-2 pt-2 border-t">
+                        <DeleteConfirm id={m.id} />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </>
+    );
+  }
+
+  // --- Blood pressure ---
+
+  return (
+    <>
+      {/* Desktop */}
+      <div className="hidden md:block border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-muted">
+            <tr>
+              <th className="text-left p-3 font-medium">Tarih</th>
+              <th className="text-right p-3 font-medium">Sistolik/Diastolik</th>
+              <th className="text-right p-3 font-medium">Nabız</th>
+              <th className="text-left p-3 font-medium">Not</th>
+              {canEdit && (
+                <th className="text-right p-3 font-medium">
+                  <span className="sr-only">İşlemler</span>
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {measurements.map((m) => {
+              const isEditing = editingId === m.id;
+              const isDeleting = deletingId === m.id;
+              const bpStatus =
+                m.systolic != null && m.diastolic != null
+                  ? getBPStatus(m.systolic, m.diastolic)
+                  : null;
+
+              return (
+                <tr
+                  key={m.id}
+                  className={cn(
+                    "border-t hover:bg-muted/50",
+                    bpStatus && bpStatus.label !== "Normal" && bpStatus.bg,
+                  )}
+                >
+                  {isEditing ? (
+                    <>
+                      <td className="p-3 text-muted-foreground">
+                        {formatDateTR(m.measured_at)}
+                      </td>
+                      <td className="p-2">
+                        <div className="flex items-center gap-1 justify-end">
+                          <Input
+                            type="number"
+                            value={editForm.systolic}
+                            onChange={updateField("systolic")}
+                            className="h-8 text-sm text-right w-20"
+                            aria-label="Sistolik"
+                          />
+                          <span className="text-muted-foreground">/</span>
+                          <Input
+                            type="number"
+                            value={editForm.diastolic}
+                            onChange={updateField("diastolic")}
+                            className="h-8 text-sm text-right w-20"
+                            aria-label="Diastolik"
+                          />
+                        </div>
+                      </td>
+                      <td className="p-2">
+                        <Input
+                          type="number"
+                          value={editForm.pulse}
+                          onChange={updateField("pulse")}
+                          className="h-8 text-sm text-right w-20 ml-auto"
+                          placeholder="—"
+                          aria-label="Nabız"
+                        />
+                      </td>
+                      <td className="p-2">
+                        <NotesInput className="w-full" />
+                      </td>
+                      <td className="p-2">
+                        <SaveCancelIcons id={m.id} />
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="p-3">{formatDateTR(m.measured_at)}</td>
+                      <td
+                        className={cn(
+                          "p-3 text-right tabular-nums font-medium",
+                          bpStatus?.color,
+                        )}
+                      >
+                        {m.systolic}/{m.diastolic}
+                        {bpStatus && bpStatus.label !== "Normal" && (
+                          <span
+                            className={cn(
+                              "ml-2 text-xs font-normal",
+                              bpStatus.color,
+                            )}
+                          >
+                            {bpStatus.label}
+                          </span>
+                        )}
+                      </td>
+                      <td className="p-3 text-right tabular-nums text-muted-foreground">
+                        {m.pulse ?? "—"}
+                      </td>
+                      <td className="p-3 text-muted-foreground truncate max-w-[200px]">
+                        {m.notes || "—"}
+                      </td>
+                      {canEdit && (
+                        <td className="p-3 text-right">
+                          {isDeleting ? (
+                            <div className="flex justify-end">
+                              <DeleteConfirm id={m.id} />
+                            </div>
+                          ) : (
+                            <div className="flex justify-end">
+                              <EditDeleteActions measurement={m} />
+                            </div>
+                          )}
+                        </td>
+                      )}
+                    </>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile */}
+      <div className="md:hidden space-y-2">
+        {measurements.map((m) => {
+          const isEditing = editingId === m.id;
+          const isDeleting = deletingId === m.id;
+          const bpStatus =
+            m.systolic != null && m.diastolic != null
+              ? getBPStatus(m.systolic, m.diastolic)
+              : null;
+
+          return (
+            <div
+              key={m.id}
+              className={cn(
+                "border rounded-lg p-3",
+                bpStatus &&
+                  bpStatus.label !== "Normal" &&
+                  `${bpStatus.bg} ${bpStatus.borderColor} border-l-2`,
+              )}
+            >
+              {isEditing ? (
+                <div className="space-y-3">
+                  <p className="text-xs text-muted-foreground">
+                    {formatDateTR(m.measured_at)}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">
+                        Sistolik
+                      </label>
+                      <Input
+                        type="number"
+                        value={editForm.systolic}
+                        onChange={updateField("systolic")}
+                        className="h-8 text-sm"
+                        aria-label="Sistolik"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">
+                        Diastolik
+                      </label>
+                      <Input
+                        type="number"
+                        value={editForm.diastolic}
+                        onChange={updateField("diastolic")}
+                        className="h-8 text-sm"
+                        aria-label="Diastolik"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">
+                        Nabız
+                      </label>
+                      <Input
+                        type="number"
+                        value={editForm.pulse}
+                        onChange={updateField("pulse")}
+                        className="h-8 text-sm"
+                        placeholder="—"
+                        aria-label="Nabız"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">
+                        Not
+                      </label>
+                      <NotesInput />
+                    </div>
+                  </div>
+                  <MobileSaveCancelButtons id={m.id} />
+                </div>
+              ) : (
+                <div>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs text-muted-foreground">
+                      {formatDateTR(m.measured_at)}
+                    </span>
+                    {canEdit && !isDeleting && (
+                      <EditDeleteActions
+                        measurement={m}
+                        iconSize="h-3 w-3"
+                        buttonSize="h-7 w-7"
+                      />
+                    )}
+                  </div>
+                  <div className="flex items-baseline gap-3 mt-1">
+                    <span
+                      className={cn(
+                        "text-lg tabular-nums font-medium",
+                        bpStatus?.color,
+                      )}
+                    >
+                      {m.systolic}/{m.diastolic}
+                    </span>
+                    {m.pulse != null && (
+                      <span className="text-sm text-muted-foreground tabular-nums">
+                        {m.pulse} bpm
+                      </span>
+                    )}
+                    {bpStatus && bpStatus.label !== "Normal" && (
+                      <span className={cn("text-xs ml-auto", bpStatus.color)}>
+                        {bpStatus.label}
+                      </span>
+                    )}
+                  </div>
+                  {m.notes && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {m.notes}
+                    </p>
+                  )}
+                  {isDeleting && (
+                    <div className="mt-2 pt-2 border-t">
+                      <DeleteConfirm id={m.id} />
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Kilo and Tansiyon tabs to settings page with URL-based tab state (`?tab=kilo`)
- New `TrackingHistory` component with inline edit (pencil → inputs) and inline delete confirmation ("Sil?" → Onayla/İptal) for both weight and blood pressure entries
- `PUT /api/tracking/[id]` endpoint for updating measurement values (not dates) with range validation
- Fix DELETE access control: viewers can no longer delete (requires owner/editor)
- Add security checklist section to CLAUDE.md documenting access control patterns

## Test plan
- [ ] Navigate to `/settings` — 3 pill tabs visible (Tahliller, Kilo, Tansiyon)
- [ ] Click Kilo tab — weight history loads, URL updates to `?tab=kilo`
- [ ] Click Tansiyon tab — BP history loads with color-coded status labels
- [ ] Edit a weight value — pencil icon → inputs appear, save persists on refresh
- [ ] Edit BP values — sistolik/diastolik/nabız editable, save works
- [ ] Delete a weight entry — trash icon → "Sil?" inline confirmation → gone after Onayla
- [ ] Check mobile responsive view — cards instead of table
- [ ] Refresh with `?tab=tansiyon` — correct tab loads directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)