### PR TITLE
fix: show blood test date instead of upload date

### DIFF
--- a/product/tasks/done/settings-tabs-tracking-history.md
+++ b/product/tasks/done/settings-tabs-tracking-history.md
@@ -1,6 +1,8 @@
 # Task: Settings Tabs — Tracking History (Kilo & Tansiyon)
 
-**Status:** Pending
+**Status:** Done
+**Completed:** 2026-02-13
+**PR:** #25
 **Priority:** High
 **Created:** 2026-02-13
 

--- a/web/src/app/api/settings/files/[id]/route.ts
+++ b/web/src/app/api/settings/files/[id]/route.ts
@@ -79,6 +79,7 @@ export async function GET(
         id: file.id,
         file_name: file.file_name,
         created_at: file.created_at,
+        sample_date: metrics[0]?.sample_date ?? null,
         profile_id: file.profile_id,
       },
       metrics,

--- a/web/src/app/settings/files/[id]/page.tsx
+++ b/web/src/app/settings/files/[id]/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
-import { formatDateTimeTR } from "@/lib/date";
+import { formatDateTR } from "@/lib/date";
 
 const EMPTY_FORM = { value: "", unit: "", ref_low: "", ref_high: "" };
 
@@ -43,6 +43,7 @@ interface FileData {
   id: string;
   file_name: string;
   created_at: string;
+  sample_date: string | null;
   profile_id: string;
 }
 
@@ -214,9 +215,11 @@ export default function FileDetailPage(): React.ReactElement {
             <FileText aria-hidden="true" className="h-5 w-5 shrink-0" />
             <span className="truncate">{file.file_name}</span>
           </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            {formatDateTimeTR(file.created_at)}
-          </p>
+          {file.sample_date && (
+            <p className="text-sm text-muted-foreground">
+              Tahlil tarihi: {formatDateTR(file.sample_date)}
+            </p>
+          )}
         </CardHeader>
         <CardContent>
           {metrics.length === 0 ? (


### PR DESCRIPTION
## Summary
- File detail page showed upload timestamp (misleading) — now shows "Tahlil tarihi: 21 Kas 2025" (the actual blood test date)
- API now returns `sample_date` in the file detail response
- Moved completed task file to `product/tasks/done/`

## Test plan
- [ ] Open any file detail from Settings → Tahliller → click a file
- [ ] Date below filename should show the blood test date, not upload date
- [ ] Files without a sample_date should show no date (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)