### PR TITLE
feat: add user context to Sentry error reports

### DIFF
--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -2,7 +2,13 @@
 
 import { SessionProvider } from "next-auth/react";
 import { ReactNode } from "react";
+import { SentryUser } from "./sentry-user";
 
 export function Providers({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <SentryUser />
+      {children}
+    </SessionProvider>
+  );
 }

--- a/web/src/components/sentry-user.tsx
+++ b/web/src/components/sentry-user.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useSession } from "next-auth/react";
+import { useEffect } from "react";
+
+export function SentryUser() {
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session?.user) {
+      Sentry.setUser({
+        id: session.user.dbId,
+        email: session.user.email ?? undefined,
+      });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [session]);
+
+  return null;
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import GoogleProvider from "next-auth/providers/google";
 import { getServerSession } from "next-auth";
 import type { NextAuthOptions } from "next-auth";
+import * as Sentry from "@sentry/nextjs";
 import { sql } from "@/lib/db";
 import { reportError } from "@/lib/error-reporting";
 
@@ -211,7 +212,11 @@ export async function getUserProfiles(userId: string): Promise<
 export async function requireAuth(): Promise<string | null> {
   const session = await getServerSession(authOptions);
   if (!session?.user?.email) return null;
-  return getDbUserId(session);
+  const userId = getDbUserId(session);
+  if (userId) {
+    Sentry.setUser({ id: userId, email: session.user.email });
+  }
+  return userId;
 }
 
 export async function requireProfileOwner(


### PR DESCRIPTION
## Summary
- Adds `Sentry.setUser({ id, email })` on both client and server side
- **Client**: new `SentryUser` component reads the NextAuth session and sets Sentry user context (clears on logout)
- **Server**: `requireAuth()` now sets Sentry user context so all API route errors are tagged with the affected user

## Why
Sentry error emails (e.g. VIZIAI-3 TypeError: Failed to fetch) currently show no user info — impossible to know who was affected. After this, every error will show the user's ID and email.

## Test plan
- [ ] Trigger a client-side error while logged in → Sentry event should show user email
- [ ] Trigger an API error → Sentry event should show user ID and email
- [ ] Log out → Sentry user context should be cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)