### PR TITLE
fix: validate timezone against IANA database

### DIFF
--- a/web/src/app/api/user/preferences/route.ts
+++ b/web/src/app/api/user/preferences/route.ts
@@ -101,9 +101,11 @@ export async function PUT(request: Request) {
       }
     }
 
-    // Validate timezone
+    // Validate timezone against IANA database
     if (timezone !== undefined) {
-      if (typeof timezone !== "string" || timezone.length === 0) {
+      try {
+        Intl.DateTimeFormat(undefined, { timeZone: timezone as string });
+      } catch {
         return NextResponse.json(
           { error: "Invalid timezone" },
           { status: 400 },


### PR DESCRIPTION
## Summary
- Validates timezone server-side using `Intl.DateTimeFormat` before saving to DB
- Invalid timezone strings (from direct API calls) would crash `toLocaleDateString()` across the entire app
- Addresses critical review finding from PR #68

## Test plan
- [ ] PUT `/api/user/preferences` with `{"timezone": "Invalid/Zone"}` → returns 400
- [ ] PUT with `{"timezone": "Europe/Madrid"}` → saves successfully
- [ ] Existing UI timezone selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)