### PR TITLE
fix: scope API keys list to active profile

### DIFF
--- a/web/src/app/api/settings/api-keys/route.ts
+++ b/web/src/app/api/settings/api-keys/route.ts
@@ -11,28 +11,48 @@ export const dynamic = "force-dynamic";
  * GET /api/settings/api-keys
  * List user's API keys (session auth)
  */
-export async function GET() {
+export async function GET(request: Request) {
   try {
     const userId = await requireAuth();
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const keys = await sql`
-      SELECT
-        ak.id,
-        ak.name,
-        ak.key_prefix,
-        ak.profile_id,
-        p.display_name as profile_name,
-        ak.created_at,
-        ak.last_used_at,
-        ak.revoked_at
-      FROM api_keys ak
-      JOIN profiles p ON p.id = ak.profile_id
-      WHERE ak.user_id = ${userId}
-      ORDER BY ak.created_at DESC
-    `;
+    const { searchParams } = new URL(request.url);
+    const profileId = searchParams.get("profileId");
+
+    const keys = profileId
+      ? await sql`
+          SELECT
+            ak.id,
+            ak.name,
+            ak.key_prefix,
+            ak.profile_id,
+            p.display_name as profile_name,
+            ak.created_at,
+            ak.last_used_at,
+            ak.revoked_at
+          FROM api_keys ak
+          JOIN profiles p ON p.id = ak.profile_id
+          WHERE ak.user_id = ${userId}
+            AND ak.profile_id = ${profileId}
+          ORDER BY ak.created_at DESC
+        `
+      : await sql`
+          SELECT
+            ak.id,
+            ak.name,
+            ak.key_prefix,
+            ak.profile_id,
+            p.display_name as profile_name,
+            ak.created_at,
+            ak.last_used_at,
+            ak.revoked_at
+          FROM api_keys ak
+          JOIN profiles p ON p.id = ak.profile_id
+          WHERE ak.user_id = ${userId}
+          ORDER BY ak.created_at DESC
+        `;
 
     return NextResponse.json({ keys });
   } catch (error) {

--- a/web/src/app/settings/api-keys/page.tsx
+++ b/web/src/app/settings/api-keys/page.tsx
@@ -63,8 +63,11 @@ export default function ApiKeysPage() {
   const [confirmRevoke, setConfirmRevoke] = useState<string | null>(null);
 
   const fetchKeys = useCallback(async () => {
+    if (!activeProfileId) return;
     try {
-      const res = await fetch("/api/settings/api-keys");
+      const res = await fetch(
+        `/api/settings/api-keys?profileId=${activeProfileId}`,
+      );
       if (!res.ok) return;
       const data = await res.json();
       setKeys(data.keys || []);
@@ -73,13 +76,14 @@ export default function ApiKeysPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [activeProfileId]);
 
   useEffect(() => {
-    if (!profilesLoading) {
+    if (!profilesLoading && activeProfileId) {
+      setLoading(true);
       fetchKeys();
     }
-  }, [profilesLoading, fetchKeys]);
+  }, [profilesLoading, activeProfileId, fetchKeys]);
 
   const handleCreate = async () => {
     if (!selectedProfileId) return;


### PR DESCRIPTION
## Summary
- API keys page now fetches only keys for the active profile (was showing all keys across all profiles)
- GET `/api/settings/api-keys` accepts optional `?profileId=` filter
- Switching profiles re-fetches the key list

## Test plan
- [ ] Create API keys on two different profiles
- [ ] Switch between profiles — only that profile's keys should be visible
- [ ] Viewer profiles still can't create keys (unchanged, already enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)