### PR TITLE
fix: Ahrefs SEO audit — links, meta, schema, hreflang

### DIFF
--- a/product/research/growth-strategy.md
+++ b/product/research/growth-strategy.md
@@ -1,0 +1,189 @@
+# ViziAI Growth Strategy
+
+**Created:** 2026-03-08
+**Status:** Draft — validated with real keyword data, not yet executed
+
+---
+
+## Two Channels, One Flywheel
+
+ViziAI growth runs on two parallel channels that feed each other:
+
+1. **Content SEO** — metric explainer blog posts targeting high-volume health keywords
+2. **Community Outreach** — genuine participation in forums, groups, social media
+
+Content SEO creates pages that community outreach links to. Community outreach drives initial traffic + backlinks that help SEO. They compound together.
+
+---
+
+## Channel 1: Content SEO (Metric Explainer Series)
+
+### The Insight
+
+People don't search for "blood test tracking app" (10-100/month). They search for "what does low ferritin mean" (10,000+/month). The product discovery happens inside the answer to a health question.
+
+### Validated Keyword Data (March 2026, Google Keyword Planner + Ahrefs)
+
+**Monster keywords (10K-100K/month, Turkey):**
+
+| Keyword                     | Volume   | Ahrefs KD |
+| --------------------------- | -------- | --------- |
+| ferritin düşüklüğü          | >10,000  | Easy      |
+| ferritin yüksekliği         | 10K-100K | —         |
+| b12 eksikliği belirtileri   | >10,000  | Easy      |
+| demir eksikliği belirtileri | 10K-100K | —         |
+| tsh yüksekliği              | 10K-100K | —         |
+| hemogram ne demek           | 10K-100K | —         |
+| kolesterol kaç olmalı       | 10K-100K | —         |
+| trigliserit yüksekliği      | 10K-100K | —         |
+| kreatinin yüksekliği        | 10K-100K | —         |
+| crp nedir                   | 10K-100K | —         |
+| magnezyum eksikliği         | 10K-100K | —         |
+| kan tahlili sonucu          | 10K-100K | —         |
+| e nabız tahlil sonuçları    | 10K-100K | —         |
+| tansiyon kaç olmalı         | 10K-100K | —         |
+
+**Dead keywords (zero or near-zero volume):**
+
+- All diaspora keywords (yurtdışından sağlık takibi, gurbetçi sağlık, etc.)
+- All app/tool keywords (kan tahlili uygulaması, sağlık takip uygulaması, etc.)
+- All AI keywords (yapay zeka kan tahlili, dijital sağlık uygulaması, etc.)
+- All family tracking keywords (aile sağlık takibi, anne baba sağlık, etc.)
+
+**Conclusion:** Nobody searches for what ViziAI IS. Thousands search for what ViziAI helps WITH.
+
+### Article Template
+
+Each metric explainer follows this structure:
+
+1. **What is [metric]?** — factual definition, what it measures
+2. **Normal reference ranges** — by age and gender, from medical guidelines
+3. **What low/high values might indicate** — educational, always with "consult your doctor"
+4. **Common symptoms** — what people actually feel (this is what they googled)
+5. **How often to check** — general guidance
+6. **Track your values over time** — natural CTA to ViziAI
+
+### Ethics & Medical Disclaimer
+
+We are NOT a medical site. Every article must:
+
+- **State facts, not diagnoses.** "Normal ferritin range is typically 12-150 ng/mL for women."
+- **Never say "you have X disease."** Say "if your levels are outside the reference range, consult your doctor."
+- **Cite sources.** Link to health ministry guidelines, WHO, medical textbook references.
+- **Include disclaimer on every article:** "Bu içerik tıbbi tavsiye niteliği taşımaz. Sağlık durumunuz hakkında mutlaka doktorunuza danışın."
+- **Match the product philosophy.** ViziAI is "data organization, not medical interpretation." The blog is the same — inform, don't diagnose.
+
+### Language Priority
+
+| Language | Opportunity   | Reasoning                                                                                 |
+| -------- | ------------- | ----------------------------------------------------------------------------------------- |
+| Turkish  | High          | Easy difficulty, less competition from medical sites, validated data                      |
+| German   | Medium-High   | Check volumes/difficulty. Fewer health content sites than English                         |
+| Dutch    | Medium        | Smaller market, but less competition                                                      |
+| Spanish  | Medium        | Large market, needs validation                                                            |
+| French   | Medium        | Needs validation                                                                          |
+| English  | Low (for SEO) | Healthline, WebMD, Cleveland Clinic own every keyword. Use English for product pages only |
+
+**Plan:** Validate in Turkish first. If it works (measurable traffic + signups within 2-3 months), expand to DE/NL/ES/FR.
+
+### Content Cadence
+
+- 1 article per week
+- Start with Turkish only
+- Each article targets one 10K+ keyword cluster
+- First 6 articles (priority order):
+
+| #   | Article                                       | Primary Keyword           | Volume   |
+| --- | --------------------------------------------- | ------------------------- | -------- |
+| 1   | Ferritin: Kaç Olmalı, Düşüklüğü ve Yüksekliği | ferritin düşüklüğü        | >10,000  |
+| 2   | B12 Eksikliği: Belirtileri ve Nedenleri       | b12 eksikliği belirtileri | >10,000  |
+| 3   | Hemogram Ne Demek? Sonuçları Nasıl Okunur?    | hemogram ne demek         | 10K-100K |
+| 4   | TSH Yüksekliği Ne Anlama Gelir?               | tsh yüksekliği            | 10K-100K |
+| 5   | Kolesterol Kaç Olmalı?                        | kolesterol kaç olmalı     | 10K-100K |
+| 6   | CRP Nedir? Yüksekliği Ne Anlama Gelir?        | crp nedir                 | 10K-100K |
+
+### Success Metrics
+
+- **Month 1-2:** Articles indexed, appearing in Google for long-tail variants
+- **Month 3-4:** First page rankings for some Easy keywords
+- **Month 6:** Measurable organic traffic (target: 500+ organic visits/month)
+- **Month 12:** Organic traffic as a consistent signup channel
+
+---
+
+## Channel 2: Community Outreach (Weekly Loop)
+
+### The Insight
+
+The people who need ViziAI most (tracking parents' health from abroad, making sense of blood tests) don't google for a tool. They ask questions in communities. Meet them there.
+
+### Platforms
+
+| Platform                   | Audience                     | Approach                                           |
+| -------------------------- | ---------------------------- | -------------------------------------------------- |
+| Reddit (r/Turkey, r/KGBTR) | Turkish internet users       | Answer health tracking questions, share experience |
+| Ekşi Sözlük                | Broad Turkish audience       | Relevant başlıklar about e-Nabız, kan tahlili      |
+| Facebook diaspora groups   | Turks in Germany/Netherlands | Help with "how to track parents' health"           |
+| Donanım Haber              | Tech-savvy Turks             | App/tool recommendations threads                   |
+| X/Twitter                  | Turkish health/wellness      | Short-form content, screenshots                    |
+| Instagram/TikTok           | Visual audience              | Reels showing ViziAI dashboard, quick tips         |
+
+### Weekly Loop (2x per week)
+
+1. **Find opportunities** — search platforms for relevant threads/discussions
+2. **Draft genuine replies** — answer the actual question, mention ViziAI only if naturally relevant
+3. **Review and post** — Onur reviews drafts and posts manually (never auto-post)
+4. **Create short-form content** — dashboard screenshots, quick health tips, e-Nabız how-to
+5. **Track what works** — which platforms drive signups?
+
+### Rules
+
+- Be genuinely helpful first. If there's no natural way to mention ViziAI, don't.
+- Sound like a real person (Onur), not a marketer.
+- Never spam. Quality over quantity.
+- Link to blog articles (drives SEO backlinks too).
+
+---
+
+## How They Connect
+
+```
+Blog article (SEO) ←→ Community post (outreach)
+       ↓                        ↓
+  Organic traffic          Direct traffic
+       ↓                        ↓
+  Reads article            Reads thread
+       ↓                        ↓
+  Discovers ViziAI         Clicks link to ViziAI
+       ↓                        ↓
+       └──────→ Signup ←────────┘
+                  ↓
+            Uses product
+                  ↓
+         Tells family/friends
+                  ↓
+            Word of mouth
+```
+
+Community outreach creates backlinks → helps SEO rankings.
+SEO content creates landing pages → community posts link to them.
+Both drive signups → word of mouth compounds.
+
+---
+
+## What's NOT in this strategy
+
+- **Paid ads** — not yet. Organic first, validate product-market fit.
+- **English SEO** — too competitive. English content is for product pages and international users, not search traffic.
+- **Diaspora-specific SEO** — zero volume. Reach diaspora through communities, not Google.
+- **AI/app keywords** — nobody searches for these. Don't optimize for them.
+
+---
+
+## Next Steps
+
+1. [ ] Write first metric explainer (ferritin) — use as template for series
+2. [ ] Set up community outreach weekly loop
+3. [ ] After first 3 articles: check indexing and early ranking signals
+4. [ ] After 2-3 months: evaluate Turkish results, decide on language expansion
+5. [ ] Check German/Dutch/Spanish keyword volumes with same methodology

--- a/web/content/blog/de/blutwerte-verstehen-tuerkisch-deutsch.mdx
+++ b/web/content/blog/de/blutwerte-verstehen-tuerkisch-deutsch.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Blutwerte verstehen: Türkisch-deutsche Übersetzung Ihrer Laborwerte"
+title: "Blutwerte auf Türkisch verstehen"
 description: "Deutsche Blutwerte auf Türkisch verstehen. ViziAI liest Ihr Blutbild automatisch, übersetzt Laborwerte und vergleicht sie mit türkischen Ergebnissen."
 locale: "de"
 slug: "blutwerte-verstehen-tuerkisch-deutsch"

--- a/web/content/blog/tr/almanya-hollanda-tahlil-sonuclari-turkce.mdx
+++ b/web/content/blog/tr/almanya-hollanda-tahlil-sonuclari-turkce.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Almanya veya Hollanda'daki Tahlil Sonuçlarınızı Türkçe Nasıl Anlarsınız?"
+title: "Yurt Dışı Tahlillerinizi Türkçe Anlayın"
 description: "Almanya tahlil sonuçlarını Türkçe anlayın. ViziAI, Almanya ve Hollanda'daki lab PDF'lerini otomatik okur, Türkiye sonuçlarınızla karşılaştırır."
 locale: "tr"
 slug: "almanya-hollanda-tahlil-sonuclari-turkce"
@@ -47,7 +47,7 @@ Diyelim ki yıllardır İstanbul'da düzenli check-up yaptırıyordunuz. Tiroid 
 
 ViziAI, Türkiye ve Almanya (veya Hollanda) raporlarınızı aynı zaman çizelgesine koyuyor. Her metrik için tek bir eğilim grafiği görüyorsunuz — İstanbul'daki check-up'tan Berlin'deki Blutbild'e kadar kesintisiz.
 
-Yıllardır e-Nabız kullananlar için tahlil geçmişi zaten orada birikmiş durumda. Mesele onu yurt dışı sonuçlarıyla birleştirebilmek. ViziAI'ın [Chrome eklentisi](/enabiz) e-Nabız'daki sonuçlarınızı çekip aktarıyor — böylece yurt dışındaki yeni tahlillerinizle Türkiye'deki geçmişiniz aynı yerde buluşuyor. Yurt dışı kan tahlili takibi tek bir yerden.
+Yıllardır e-Nabız kullananlar için tahlil geçmişi zaten orada birikmiş durumda. Mesele onu yurt dışı sonuçlarıyla birleştirebilmek. ViziAI'ın [Chrome eklentisi](/tr/enabiz-rehberi) e-Nabız'daki sonuçlarınızı çekip aktarıyor — böylece yurt dışındaki yeni tahlillerinizle Türkiye'deki geçmişiniz aynı yerde buluşuyor. Yurt dışı kan tahlili takibi tek bir yerden.
 
 ## Sıkça Sorulan Sorular
 

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -561,6 +561,7 @@
   "faq": {
     "title": "Häufig gestellte Fragen",
     "subtitle": "Alles, was Sie über ViziAI wissen müssen",
+    "metaDescription": "Wie ViziAI funktioniert, wie Sie Laborergebnisse hochladen, aus e-Nabız importieren, Trends verfolgen und Familienprofile verwalten.",
     "questions": {
       "whatIsViziAI": {
         "q": "Was ist ViziAI?",
@@ -642,6 +643,7 @@
   "enabizGuide": {
     "title": "e-Nabız Chrome-Erweiterung Anleitung",
     "subtitle": "Schritt-für-Schritt-Anleitung zum Importieren Ihrer e-Nabız-Laborergebnisse in ViziAI.",
+    "metaDescription": "Importieren Sie Ihre e-Nabız-Laborhistorie mit einem Klick in ViziAI. Sehen Sie Jahre von Blutwerten als Diagramme, verfolgen Sie Trends und verwalten Sie Familienprofile.",
     "desktopOnly": "Chrome-Erweiterungen funktionieren nur mit Desktop-Chrome, nicht auf Mobilgeräten. Nach dem Import von einem Computer können Sie Ihre Ergebnisse auf jedem Gerät ansehen.",
     "steps": {
       "step1": {
@@ -674,8 +676,8 @@
     "createKeyCta": "API-Schlüssel erstellen"
   },
   "blog": {
-    "listTitle": "Blog — ViziAI",
-    "listDescription": "Artikel über Blutwerte-Tracking, Gesundheitsanalyse und ViziAI.",
+    "listTitle": "Blutwerte-Ratgeber und Gesundheitstipps | ViziAI",
+    "listDescription": "Ratgeber zu Blutwerten, e-Nabız-Import, Gesundheitstrends verfolgen und Laborergebnisse aus verschiedenen Ländern mit KI vergleichen.",
     "listHeading": "Blog",
     "listEmpty": "Noch keine Artikel veröffentlicht.",
     "back": "Zurück zum Blog",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -561,6 +561,7 @@
   "faq": {
     "title": "Frequently Asked Questions",
     "subtitle": "Everything you need to know about ViziAI",
+    "metaDescription": "How ViziAI works, how to upload lab results, import from e-Nabız, track trends, and manage family profiles. Common questions answered.",
     "questions": {
       "whatIsViziAI": {
         "q": "What is ViziAI?",
@@ -642,6 +643,7 @@
   "enabizGuide": {
     "title": "e-Nabız Chrome Extension Guide",
     "subtitle": "Step-by-step setup to import your e-Nabız lab results into ViziAI.",
+    "metaDescription": "Import your full e-Nabız lab history into ViziAI with one click. See years of blood test data as visual charts, track trends, and manage family profiles.",
     "desktopOnly": "Chrome extensions only work on desktop Chrome, not on mobile devices. After importing from a computer, you can view your results on any device.",
     "steps": {
       "step1": {
@@ -674,8 +676,8 @@
     "createKeyCta": "Create API Key"
   },
   "blog": {
-    "listTitle": "Blog — ViziAI",
-    "listDescription": "Articles about blood test tracking, health analysis, and ViziAI.",
+    "listTitle": "Blood Test Guides and Health Insights | ViziAI",
+    "listDescription": "Guides on understanding blood test results, importing from e-Nabız, tracking health trends over time, and comparing lab reports across countries with AI.",
     "listHeading": "Blog",
     "listEmpty": "No articles published yet.",
     "back": "Back to Blog",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -561,6 +561,7 @@
   "faq": {
     "title": "Preguntas Frecuentes",
     "subtitle": "Todo lo que necesitas saber sobre ViziAI",
+    "metaDescription": "Cómo funciona ViziAI, cómo subir resultados de laboratorio, importar desde e-Nabız, seguir tendencias y gestionar perfiles familiares.",
     "questions": {
       "whatIsViziAI": {
         "q": "¿Qué es ViziAI?",
@@ -642,6 +643,7 @@
   "enabizGuide": {
     "title": "Guía de la extensión Chrome e-Nabız",
     "subtitle": "Configuración paso a paso para importar tus resultados de laboratorio de e-Nabız a ViziAI.",
+    "metaDescription": "Importa todo tu historial de e-Nabız a ViziAI con un clic. Visualiza años de análisis de sangre en gráficos, sigue tendencias y gestiona perfiles familiares.",
     "desktopOnly": "Las extensiones de Chrome solo funcionan en Chrome de escritorio, no en dispositivos móviles. Después de importar desde un ordenador, puedes ver tus resultados en cualquier dispositivo.",
     "steps": {
       "step1": {
@@ -674,8 +676,8 @@
     "createKeyCta": "Crear clave API"
   },
   "blog": {
-    "listTitle": "Blog — ViziAI",
-    "listDescription": "Artículos sobre seguimiento de análisis de sangre, salud y ViziAI.",
+    "listTitle": "Guías de Análisis de Sangre y Salud | ViziAI",
+    "listDescription": "Guías sobre análisis de sangre, importación desde e-Nabız, seguimiento de tendencias de salud y comparación de resultados de laboratorio entre países con IA.",
     "listHeading": "Blog",
     "listEmpty": "Aún no se han publicado artículos.",
     "back": "Volver al Blog",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -561,6 +561,7 @@
   "faq": {
     "title": "Questions Fréquentes",
     "subtitle": "Tout ce que vous devez savoir sur ViziAI",
+    "metaDescription": "Comment fonctionne ViziAI, comment télécharger vos résultats, importer depuis e-Nabız, suivre les tendances et gérer les profils familiaux.",
     "questions": {
       "whatIsViziAI": {
         "q": "Qu'est-ce que ViziAI ?",
@@ -642,6 +643,7 @@
   "enabizGuide": {
     "title": "Guide de l'extension Chrome e-Nabız",
     "subtitle": "Configuration étape par étape pour importer vos résultats de laboratoire e-Nabız dans ViziAI.",
+    "metaDescription": "Importez votre historique e-Nabız dans ViziAI en un clic. Visualisez des années d'analyses de sang en graphiques, suivez les tendances et gérez les profils familiaux.",
     "desktopOnly": "Les extensions Chrome ne fonctionnent que sur Chrome de bureau, pas sur les appareils mobiles. Après l'importation depuis un ordinateur, vous pouvez consulter vos résultats sur n'importe quel appareil.",
     "steps": {
       "step1": {
@@ -674,8 +676,8 @@
     "createKeyCta": "Créer une clé API"
   },
   "blog": {
-    "listTitle": "Blog — ViziAI",
-    "listDescription": "Articles sur le suivi des analyses de sang, la santé et ViziAI.",
+    "listTitle": "Guides Analyses de Sang et Santé | ViziAI",
+    "listDescription": "Guides sur les analyses de sang, l'importation depuis e-Nabız, le suivi des tendances de santé et la comparaison de résultats entre pays avec l'IA.",
     "listHeading": "Blog",
     "listEmpty": "Aucun article publié pour le moment.",
     "back": "Retour au Blog",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -561,6 +561,7 @@
   "faq": {
     "title": "Veelgestelde vragen",
     "subtitle": "Alles wat je moet weten over ViziAI",
+    "metaDescription": "Hoe ViziAI werkt, hoe je labresultaten uploadt, importeert vanuit e-Nabız, trends volgt en familieprofielen beheert. Antwoorden op veelgestelde vragen.",
     "questions": {
       "whatIsViziAI": {
         "q": "Wat is ViziAI?",
@@ -642,6 +643,7 @@
   "enabizGuide": {
     "title": "e-Nabız Chrome-extensie Handleiding",
     "subtitle": "Stapsgewijze installatie om je e-Nabız labresultaten te importeren in ViziAI.",
+    "metaDescription": "Importeer je volledige e-Nabız labhistorie in ViziAI met één klik. Bekijk jaren aan bloedwaarden als grafieken, volg trends en beheer familieprofielen.",
     "desktopOnly": "Chrome-extensies werken alleen op desktop Chrome, niet op mobiele apparaten. Na het importeren vanaf een computer kun je je resultaten op elk apparaat bekijken.",
     "steps": {
       "step1": {
@@ -674,8 +676,8 @@
     "createKeyCta": "API-sleutel aanmaken"
   },
   "blog": {
-    "listTitle": "Blog — ViziAI",
-    "listDescription": "Artikelen over het volgen van bloedtests, gezondheidsanalyse en ViziAI.",
+    "listTitle": "Bloedwaarden-gidsen en Gezondheidstips | ViziAI",
+    "listDescription": "Gidsen over bloedwaarden, importeren vanuit e-Nabız, gezondheidstrends volgen en labresultaten uit verschillende landen vergelijken met AI.",
     "listHeading": "Blog",
     "listEmpty": "Nog geen artikelen gepubliceerd.",
     "back": "Terug naar Blog",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -561,6 +561,7 @@
   "faq": {
     "title": "Sıkça Sorulan Sorular",
     "subtitle": "ViziAI hakkında merak ettikleriniz",
+    "metaDescription": "ViziAI nasıl çalışır, tahlil nasıl yüklenir, e-Nabız aktarımı nasıl yapılır? Kan tahlili takip platformu hakkında sık sorulan sorular ve yanıtları.",
     "questions": {
       "whatIsViziAI": {
         "q": "ViziAI nedir?",
@@ -642,6 +643,7 @@
   "enabizGuide": {
     "title": "e-Nabız Chrome Eklentisi Rehberi",
     "subtitle": "e-Nabız'daki tahlil sonuçlarınızı ViziAI'a aktarmak için kurulum rehberi.",
+    "metaDescription": "e-Nabız'daki tüm tahlil geçmişinizi ViziAI'a aktarın. Yılların kan tahlili verilerini grafiklerle görün, trendleri takip edin, aile profillerini yönetin.",
     "desktopOnly": "Chrome eklentileri sadece masaüstü Chrome ile çalışır. Mobil cihazlarda çalışmaz. İşlemi bir bilgisayardan yaptıktan sonra değerlerinizi mobil cihazlardan görüntüleyebilirsiniz.",
     "steps": {
       "step1": {
@@ -674,8 +676,8 @@
     "createKeyCta": "API Anahtarı Oluştur"
   },
   "blog": {
-    "listTitle": "Blog — ViziAI",
-    "listDescription": "Kan testi takibi, sağlık analizi ve ViziAI hakkında yazılar.",
+    "listTitle": "Kan Tahlili Rehberleri ve Sağlık Yazıları | ViziAI",
+    "listDescription": "Kan tahlili sonuçlarını anlama, e-Nabız aktarımı ve yurt dışı tahlil karşılaştırması rehberleri. PDF raporlarınızı yapay zeka ile analiz edin.",
     "listHeading": "Blog",
     "listEmpty": "Henüz yazı yayınlanmadı.",
     "back": "Blog'a dön",

--- a/web/src/app/[locale]/[slug]/page.tsx
+++ b/web/src/app/[locale]/[slug]/page.tsx
@@ -42,24 +42,24 @@ export async function generateMetadata({
   params,
 }: StaticPageProps): Promise<Metadata> {
   const { locale, slug } = await params;
-  const pageId = resolvePageId(toLocale(locale), slug);
+  const loc = toLocale(locale);
+  const pageId = resolvePageId(loc, slug);
   if (!pageId) return { title: "Not Found" };
 
-  const t = await getTranslations({
-    locale: toLocale(locale),
-    namespace: pageId,
-  });
+  const t = await getTranslations({ locale: loc, namespace: pageId });
 
-  const alternateLanguages: Record<string, string> = {};
-  for (const loc of locales) {
-    alternateLanguages[bcp47[loc]] =
-      `${BASE_URL}/${loc}/${staticPages[pageId][loc]}`;
+  const alternateLanguages: Record<string, string> = {
+    "x-default": `${BASE_URL}/en/${staticPages[pageId].en}`,
+  };
+  for (const l of locales) {
+    alternateLanguages[bcp47[l]] = `${BASE_URL}/${l}/${staticPages[pageId][l]}`;
   }
-  alternateLanguages["x-default"] = `${BASE_URL}/en/${staticPages[pageId].en}`;
 
   let description = t("title");
   if (pageId === "privacy") {
     description = t("intro");
+  } else if (t.has("metaDescription")) {
+    description = t("metaDescription");
   } else if (t.has("subtitle")) {
     description = t("subtitle");
   }
@@ -94,16 +94,14 @@ const FAQ_KEYS = [
 
 export default async function StaticPage({ params }: StaticPageProps) {
   const { locale, slug } = await params;
-  const pageId = resolvePageId(toLocale(locale), slug);
+  const loc = toLocale(locale);
+  const pageId = resolvePageId(loc, slug);
   if (!pageId) notFound();
 
   const Component = pageComponents[pageId];
 
   if (pageId === "faq") {
-    const faqT = await getTranslations({
-      locale: toLocale(locale),
-      namespace: "faq",
-    });
+    const faqT = await getTranslations({ locale: loc, namespace: "faq" });
     const faqSchema = {
       "@context": "https://schema.org",
       "@type": "FAQPage",

--- a/web/src/app/[locale]/blog/[slug]/page.tsx
+++ b/web/src/app/[locale]/blog/[slug]/page.tsx
@@ -20,7 +20,7 @@ import {
   getHreflangAlternates,
 } from "@/lib/blog";
 import { TableOfContents } from "@/components/blog/TableOfContents";
-import { locales, bcp47 } from "@/i18n/config";
+import { locales, bcp47, toLocale } from "@/i18n/config";
 import type { Locale } from "@/i18n/config";
 import { BASE_URL } from "@/lib/constants";
 
@@ -45,20 +45,29 @@ export async function generateMetadata({
   params,
 }: ArticlePageProps): Promise<Metadata> {
   const { locale, slug } = await params;
-  if (!locales.includes(locale as Locale)) return { title: "Not Found" };
+  const loc = toLocale(locale);
+  if (!locales.includes(loc)) return { title: "Not Found" };
   const post = getBlogPost(locale, slug);
   if (!post) return { title: "Not Found" };
 
   const { frontmatter } = post;
   const canonicalUrl = `${BASE_URL}/${locale}/blog/${slug}`;
+  const ogImage = `${BASE_URL}/og/blog-${locale}.jpg`;
 
-  // Build hreflang alternates if this post belongs to a group
   const languages: Record<string, string> = {};
   if (frontmatter.hreflangGroup) {
     const alternates = getHreflangAlternates(frontmatter.hreflangGroup);
     for (const [altLocale, altSlug] of Object.entries(alternates)) {
       languages[bcp47[altLocale as Locale]] =
         `${BASE_URL}/${altLocale}/blog/${altSlug}`;
+    }
+    const defaultLocale = alternates.en ? "en" : Object.keys(alternates)[0];
+    const defaultSlug = alternates.en
+      ? alternates.en
+      : Object.values(alternates)[0];
+    if (defaultLocale && defaultSlug) {
+      languages["x-default"] =
+        `${BASE_URL}/${defaultLocale}/blog/${defaultSlug}`;
     }
   }
 
@@ -77,42 +86,46 @@ export async function generateMetadata({
       tags: frontmatter.tags,
       url: canonicalUrl,
       siteName: "ViziAI",
-      locale: bcp47[locale as Locale],
+      locale: bcp47[loc],
       images: [
-        {
-          url: `${BASE_URL}/og/blog-${locale}.jpg`,
-          width: 1280,
-          height: 838,
-          alt: frontmatter.title,
-        },
+        { url: ogImage, width: 1280, height: 838, alt: frontmatter.title },
       ],
     },
     twitter: {
       card: "summary_large_image",
       title: frontmatter.title,
       description: frontmatter.description,
-      images: [`${BASE_URL}/og/blog-${locale}.jpg`],
+      images: [ogImage],
     },
   };
 }
 
+function headingWithId(
+  Tag: "h2" | "h3",
+  props: React.ComponentProps<"h2">,
+): React.ReactNode {
+  const text = String(props.children);
+  return <Tag id={slugifyHeading(text)} {...props} />;
+}
+
+const mdxComponents = {
+  h2: (props: React.ComponentProps<"h2">) => headingWithId("h2", props),
+  h3: (props: React.ComponentProps<"h3">) => headingWithId("h3", props),
+};
+
 export default async function BlogArticlePage({ params }: ArticlePageProps) {
   const { locale, slug } = await params;
-  if (!locales.includes(locale as Locale)) notFound();
+  const loc = toLocale(locale);
+  if (!locales.includes(loc)) notFound();
 
   const post = getBlogPost(locale, slug);
   if (!post) notFound();
 
   const { frontmatter, content, readingTime } = post;
-  const t = await getTranslations({
-    locale: locale as Locale,
-    namespace: "blog",
-  });
-
+  const t = await getTranslations({ locale: loc, namespace: "blog" });
   const canonicalUrl = `${BASE_URL}/${locale}/blog/${slug}`;
 
-  // BlogPosting JSON-LD
-  const blogPostingJsonLd: Record<string, unknown> = {
+  const blogPostingJsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline: frontmatter.title,
@@ -133,46 +146,27 @@ export default async function BlogArticlePage({ params }: ArticlePageProps) {
       "@type": "WebPage",
       "@id": canonicalUrl,
     },
-    inLanguage: bcp47[locale as Locale],
+    inLanguage: bcp47[loc],
   };
 
   const headings = extractHeadings(content);
 
-  // Custom MDX components to inject id attributes on headings
-  const mdxComponents = {
-    h2: (props: React.ComponentProps<"h2">) => {
-      const text =
-        typeof props.children === "string"
-          ? props.children
-          : String(props.children);
-      return <h2 id={slugifyHeading(text)} {...props} />;
-    },
-    h3: (props: React.ComponentProps<"h3">) => {
-      const text =
-        typeof props.children === "string"
-          ? props.children
-          : String(props.children);
-      return <h3 id={slugifyHeading(text)} {...props} />;
-    },
-  };
-
-  // FAQPage JSON-LD (only if the post has FAQ content)
   const faqPairs = extractFaqFromContent(content);
-  let faqJsonLd: Record<string, unknown> | null = null;
-  if (faqPairs.length > 0) {
-    faqJsonLd = {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      mainEntity: faqPairs.map((faq) => ({
-        "@type": "Question",
-        name: faq.question,
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: faq.answer,
-        },
-      })),
-    };
-  }
+  const faqJsonLd =
+    faqPairs.length > 0
+      ? {
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqPairs.map((faq) => ({
+            "@type": "Question",
+            name: faq.question,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: faq.answer,
+            },
+          })),
+        }
+      : null;
 
   return (
     <div className="min-h-screen bg-background">

--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { LandingPage } from "@/components/landing-page";
-import { locales, bcp47 } from "@/i18n/config";
-import type { Locale } from "@/i18n/config";
+import { locales, bcp47, toLocale } from "@/i18n/config";
 import { BASE_URL } from "@/lib/constants";
 
 interface HomePageProps {
@@ -18,74 +17,67 @@ export async function generateMetadata({
   params,
 }: HomePageProps): Promise<Metadata> {
   const { locale } = await params;
-  if (!locales.includes(locale as Locale)) return { title: "Not Found" };
-  const t = await getTranslations({
-    locale: locale as Locale,
-    namespace: "seo",
-  });
+  const loc = toLocale(locale);
+  if (!locales.includes(loc)) return { title: "Not Found" };
+
+  const t = await getTranslations({ locale: loc, namespace: "seo" });
+  const title = t("landingTitle");
+  const description = t("landingDescription");
+  const ogImage = `${BASE_URL}/og/home-${locale}.jpg`;
 
   const alternateLanguages: Record<string, string> = {
     "x-default": `${BASE_URL}/en`,
   };
-  for (const loc of locales) {
-    alternateLanguages[bcp47[loc]] = `${BASE_URL}/${loc}`;
+  for (const l of locales) {
+    alternateLanguages[bcp47[l]] = `${BASE_URL}/${l}`;
   }
 
   return {
-    title: t("landingTitle"),
-    description: t("landingDescription"),
+    title,
+    description,
     alternates: {
       canonical: `${BASE_URL}/${locale}`,
       languages: alternateLanguages,
     },
     openGraph: {
-      title: t("landingTitle"),
-      description: t("landingDescription"),
+      title,
+      description,
       url: `${BASE_URL}/${locale}`,
       siteName: "ViziAI",
       type: "website",
-      locale: bcp47[locale as Locale],
+      locale: bcp47[loc],
       images: [
-        {
-          url: `${BASE_URL}/og/home-${locale}.jpg`,
-          width: 1280,
-          height: 838,
-          alt: t("ogImageAlt"),
-        },
+        { url: ogImage, width: 1280, height: 838, alt: t("ogImageAlt") },
       ],
     },
     twitter: {
       card: "summary_large_image",
-      title: t("landingTitle"),
-      description: t("landingDescription"),
-      images: [`${BASE_URL}/og/home-${locale}.jpg`],
+      title,
+      description,
+      images: [ogImage],
     },
   };
 }
 
 export default async function LocaleHomePage({ params }: HomePageProps) {
   const { locale } = await params;
-  if (!locales.includes(locale as Locale)) notFound();
+  const loc = toLocale(locale);
+  if (!locales.includes(loc)) notFound();
 
-  const t = await getTranslations({
-    locale: locale as Locale,
-    namespace: "seo",
-  });
+  const t = await getTranslations({ locale: loc, namespace: "seo" });
 
   const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
+    "@type": "WebSite",
     name: "ViziAI",
-    url: `${BASE_URL}/${locale}`,
-    applicationCategory: "HealthApplication",
-    operatingSystem: "Web",
-    inLanguage: bcp47[locale as Locale],
-    offers: {
-      "@type": "Offer",
-      price: "0",
-      priceCurrency: "USD",
-    },
+    url: BASE_URL,
+    inLanguage: bcp47[loc],
     description: t("landingDescription"),
+    publisher: {
+      "@type": "Organization",
+      name: "ViziAI",
+      url: BASE_URL,
+    },
   };
 
   return (

--- a/web/src/components/landing-footer.tsx
+++ b/web/src/components/landing-footer.tsx
@@ -2,45 +2,56 @@ import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
 import { LocaleSwitcher } from "@/components/locale-switcher";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { staticPages, toLocale } from "@/i18n/config";
+import { locales, localeLabels, staticPages, toLocale } from "@/i18n/config";
+
+const linkClass = "hover:text-foreground transition-colors";
 
 export async function LandingFooter() {
-  const locale = await getLocale();
+  const rawLocale = await getLocale();
+  const locale = toLocale(rawLocale);
   const t = await getTranslations("common");
+
+  const otherLocales = locales.filter((l) => l !== locale);
 
   return (
     <footer className="border-t border-border/60 bg-teal-50/50 dark:bg-teal-950/30 py-6 mt-auto">
       <div className="container mx-auto px-4 max-w-4xl">
         <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
           <Link
-            href={`/${locale}/${staticPages.privacy[toLocale(locale)]}`}
-            className="hover:text-foreground transition-colors"
+            href={`/${locale}/${staticPages.privacy[locale]}`}
+            className={linkClass}
           >
             {t("privacyLink")}
           </Link>
           <span className="text-border">|</span>
           <Link
-            href={`/${locale}/${staticPages.faq[toLocale(locale)]}`}
-            className="hover:text-foreground transition-colors"
+            href={`/${locale}/${staticPages.faq[locale]}`}
+            className={linkClass}
           >
             {t("faqLink")}
           </Link>
           <span className="text-border">|</span>
           <Link
-            href={`/${locale}/${staticPages.enabizGuide[toLocale(locale)]}`}
-            className="hover:text-foreground transition-colors"
+            href={`/${locale}/${staticPages.enabizGuide[locale]}`}
+            className={linkClass}
           >
             {t("enabizGuideLink")}
           </Link>
           <span className="text-border">|</span>
-          <Link
-            href={`/${locale}/blog`}
-            className="hover:text-foreground transition-colors"
-          >
+          <Link href={`/${locale}/blog`} className={linkClass}>
             {t("blog")}
           </Link>
           <span className="text-border">|</span>
           <LocaleSwitcher showFullName />
+          <span className="text-border">|</span>
+          {otherLocales.map((l, i) => (
+            <span key={l} className="contents">
+              {i > 0 && <span className="text-border">·</span>}
+              <Link href={`/${l}`} className={linkClass} hrefLang={l}>
+                {localeLabels[l]}
+              </Link>
+            </span>
+          ))}
           <span className="text-border">|</span>
           <ThemeToggle />
         </div>


### PR DESCRIPTION
## Summary
- Fix broken `/enabiz` link in blog article, add crawlable `<a>` locale links in landing footer
- Rewrite meta descriptions (110-160 chars) for blog listing, FAQ, and e-Nabız guide pages across all 6 locales; shorten over-length blog post titles (TR, DE)
- Replace `SoftwareApplication` JSON-LD (requires reviews) with `WebSite` schema; add missing `x-default` hreflang for blog posts
- Include growth strategy doc

## Test plan
- [ ] Verify `/tr/blog/almanya-hollanda-tahlil-sonuclari-turkce` no longer links to `/enabiz`
- [ ] Check footer renders locale links as crawlable `<a>` tags
- [ ] Validate JSON-LD on homepage with Google Rich Results Test
- [ ] Confirm meta descriptions are 110-160 chars on blog, FAQ, e-Nabız guide pages
- [ ] Verify hreflang x-default present on blog post pages (view source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)