### PR TITLE
fix: add 'confirming' status to pending_uploads CHECK constraint

### DIFF
--- a/db-schema/migrations/20260309_pending_uploads_add_confirming_status.sql
+++ b/db-schema/migrations/20260309_pending_uploads_add_confirming_status.sql
@@ -1,0 +1,10 @@
+-- Add 'confirming' to pending_uploads status CHECK constraint.
+-- The confirm endpoint uses 'confirming' as an intermediate status to prevent
+-- duplicate confirmations, but it was never added to the allowed values.
+
+ALTER TABLE pending_uploads
+  DROP CONSTRAINT pending_uploads_status_check;
+
+ALTER TABLE pending_uploads
+  ADD CONSTRAINT pending_uploads_status_check
+  CHECK (status IN ('pending', 'extracting', 'review', 'confirming', 'confirmed', 'rejected'));

--- a/web/e2e/db-constraints.spec.ts
+++ b/web/e2e/db-constraints.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.NEON_DATABASE_URL!);
+
+/**
+ * DB constraint validation tests.
+ *
+ * These tests query the actual database to ensure CHECK constraints
+ * match the statuses used in application code. Prevents the bug where
+ * code uses a status value that the DB constraint rejects.
+ */
+test.describe("DB CHECK constraints match application code", () => {
+  test("pending_uploads status constraint includes all statuses used in code", async () => {
+    // Statuses used in application code:
+    // - 'pending'     → initial status on upload creation (upload/route.ts)
+    // - 'extracting'  → set when extraction starts (upload/[id]/extract/route.ts)
+    // - 'review'      → set when extraction completes
+    // - 'confirming'  → set atomically in confirm route to prevent double-confirms
+    // - 'confirmed'   → set after metrics are saved
+    // - 'rejected'    → set when user cancels
+    const expectedStatuses = [
+      "pending",
+      "extracting",
+      "review",
+      "confirming",
+      "confirmed",
+      "rejected",
+    ];
+
+    const constraints = await sql`
+      SELECT check_clause
+      FROM information_schema.check_constraints
+      WHERE constraint_name = 'pending_uploads_status_check'
+    `;
+
+    expect(constraints.length).toBe(1);
+    const clause = constraints[0].check_clause as string;
+
+    for (const status of expectedStatuses) {
+      expect(
+        clause,
+        `Status '${status}' must be in pending_uploads CHECK constraint`,
+      ).toContain(`'${status}'`);
+    }
+  });
+
+  test("pending_imports status constraint includes all statuses used in code", async () => {
+    // Statuses used in e-Nabız import code:
+    // - 'pending'    → initial status
+    // - 'confirmed'  → after user confirms import
+    // - 'skipped'    → when user skips/rejects
+    const expectedStatuses = ["pending", "confirmed", "skipped"];
+
+    const constraints = await sql`
+      SELECT check_clause
+      FROM information_schema.check_constraints
+      WHERE constraint_name = 'pending_imports_status_check'
+    `;
+
+    expect(constraints.length).toBe(1);
+    const clause = constraints[0].check_clause as string;
+
+    for (const status of expectedStatuses) {
+      expect(
+        clause,
+        `Status '${status}' must be in pending_imports CHECK constraint`,
+      ).toContain(`'${status}'`);
+    }
+  });
+});

--- a/web/src/app/api/upload/[id]/confirm/route.ts
+++ b/web/src/app/api/upload/[id]/confirm/route.ts
@@ -271,7 +271,10 @@ export async function POST(
   } catch (error) {
     reportError(error, { op: "upload.confirm.POST" });
     return NextResponse.json(
-      { error: "Failed to confirm upload" },
+      {
+        error: "Failed to confirm upload",
+        message: "Failed to confirm upload",
+      },
       { status: 500 },
     );
   }


### PR DESCRIPTION
## Summary

- The confirm endpoint sets `status='confirming'` to prevent double-confirms, but this value was missing from the DB CHECK constraint — causing `NeonDbError` on every upload confirmation ([VIZIAI-8](https://jnuo.sentry.io/issues/101803599/))
- Adds DB constraint integration tests (`e2e/db-constraints.spec.ts`) that verify CHECK constraints match application code statuses
- Includes `message` field in the 500 error response so the UI shows a useful error instead of generic "Onaylama başarısız"

## Test plan

- [x] DB constraint test fails before migration (verified `'confirming'` missing)
- [x] Migration applied to production DB
- [x] DB constraint test passes after migration (both local and production)
- [x] Verified `UPDATE status='confirming'` succeeds on production DB
- [x] User confirmed upload works on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)