### PR TITLE
fix: serve .txt/.xml files from public without middleware

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -159,6 +159,6 @@ export const config = {
      * - public files (images, etc.)
      * - api/auth (NextAuth routes)
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|api/auth).*)",
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|txt|xml)$|api/auth).*)",
   ],
 };


### PR DESCRIPTION
## Summary
- Middleware matcher was intercepting `.txt` and `.xml` files in `public/`, causing IndexNow key file and other static files to return HTML instead of raw content
- Added `txt` and `xml` to the exclusion pattern alongside existing image extensions

## Test plan
- [ ] After deploy, `https://www.viziai.app/1cc8bb583a8c4e5cb19c7f63482abd0c.txt` returns plain text key
- [ ] `https://www.viziai.app/llms.txt` returns plain text
- [ ] Sitemap XML still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)