### PR TITLE
feat: unify metric processing across all import flows

### DIFF
--- a/web/src/app/api/admin/reports/[id]/review/route.ts
+++ b/web/src/app/api/admin/reports/[id]/review/route.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@/lib/auth";
 import { sql } from "@/lib/db";
 import { reportError } from "@/lib/error-reporting";
 import { isValidUUID } from "@/lib/utils";
+import { processMetric } from "@/lib/metric-definitions";
 
 export const dynamic = "force-dynamic";
 
@@ -72,7 +73,6 @@ export async function POST(
     }
 
     // Apply metric corrections if provided
-    // The WHERE clause guards ownership — no separate SELECT needed
     if (body.corrections && body.corrections.length > 0) {
       for (const c of body.corrections) {
         if (!c.metricId || !isValidUUID(c.metricId)) continue;
@@ -117,13 +117,48 @@ export async function POST(
         if (!hasName && !hasValue && !hasUnit && !hasRefLow && !hasRefHigh)
           continue;
 
+        // Read existing metric to merge with corrections
+        const existingRows = await sql`
+          SELECT name, value, unit, ref_low, ref_high
+          FROM metrics
+          WHERE id = ${c.metricId} AND report_id = ${id}
+        `;
+        if (existingRows.length === 0) continue;
+
+        const existing = existingRows[0];
+
+        // Merge corrections with existing values
+        const mergedName = hasName ? c.name! : (existing.name as string);
+        const mergedValue = hasValue
+          ? c.value!
+          : (existing.value as number);
+        const mergedUnit = hasUnit ? c.unit : (existing.unit as string | null);
+        const mergedRefLow = hasRefLow
+          ? c.refLow
+          : (existing.ref_low as number | null);
+        const mergedRefHigh = hasRefHigh
+          ? c.refHigh
+          : (existing.ref_high as number | null);
+
+        // Re-process through the unified pipeline (handles name resolution, unit conversion, flag calculation)
+        const processed = await processMetric({
+          name: mergedName,
+          value: mergedValue,
+          unit: mergedUnit,
+          ref_low: mergedRefLow,
+          ref_high: mergedRefHigh,
+        });
+
+        // Update with processed values
         await sql`
           UPDATE metrics SET
-            name = CASE WHEN ${hasName} THEN ${c.name ?? null} ELSE name END,
-            value = CASE WHEN ${hasValue} THEN ${c.value ?? null} ELSE value END,
-            unit = CASE WHEN ${hasUnit} THEN ${c.unit ?? null} ELSE unit END,
-            ref_low = CASE WHEN ${hasRefLow} THEN ${c.refLow ?? null} ELSE ref_low END,
-            ref_high = CASE WHEN ${hasRefHigh} THEN ${c.refHigh ?? null} ELSE ref_high END
+            name = ${mergedName},
+            value = ${processed.value},
+            unit = ${processed.unit},
+            ref_low = ${processed.refLow},
+            ref_high = ${processed.refHigh},
+            flag = ${processed.flag},
+            metric_definition_id = ${processed.definitionId}
           WHERE id = ${c.metricId} AND report_id = ${id}
         `;
       }

--- a/web/src/app/api/import/enabiz/pending/[id]/confirm/route.ts
+++ b/web/src/app/api/import/enabiz/pending/[id]/confirm/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { requireAuth, getProfileAccessLevel } from "@/lib/auth";
 import { sql } from "@/lib/db";
 import { reportError } from "@/lib/error-reporting";
+import {
+  processMetricsBatch,
+  trackUnmappedMetrics,
+  type RawMetric,
+} from "@/lib/metric-definitions";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -17,17 +22,6 @@ interface ConfirmRequest {
   }>;
   collisionAction?: "overwrite" | "skip" | "create_separate";
   collisionReportId?: string;
-}
-
-function determineFlag(
-  value: number,
-  refLow: number | null | undefined,
-  refHigh: number | null | undefined,
-): string | null {
-  if (refLow != null && value < refLow) return "L";
-  if (refHigh != null && value > refHigh) return "H";
-  if (refLow != null || refHigh != null) return "N";
-  return null;
 }
 
 /**
@@ -158,37 +152,58 @@ export async function POST(
       console.log(`[API] Created new report: ${reportId} from e-Nabız import`);
     }
 
+    // Filter valid metrics and process through unified pipeline
+    const validMetrics = body.metrics.filter(
+      (m) => typeof m.value === "number" && !isNaN(m.value),
+    );
+
+    // Process all metrics through the unified pipeline (resolve + convert + flag)
+    const rawMetrics: RawMetric[] = validMetrics.map((m) => ({
+      name: m.name,
+      value: m.value,
+      unit: m.unit,
+      ref_low: m.ref_low,
+      ref_high: m.ref_high,
+    }));
+    const processedMetrics = await processMetricsBatch(rawMetrics);
+
     // Insert metrics
     let insertedCount = 0;
-    for (const metric of body.metrics) {
-      if (typeof metric.value !== "number" || isNaN(metric.value)) continue;
-
-      const flag = determineFlag(metric.value, metric.ref_low, metric.ref_high);
+    for (let i = 0; i < processedMetrics.length; i++) {
+      const metric = validMetrics[i];
+      const processed = processedMetrics[i];
 
       await sql`
-        INSERT INTO metrics (report_id, name, value, unit, ref_low, ref_high, flag)
+        INSERT INTO metrics (report_id, name, value, unit, ref_low, ref_high, flag, metric_definition_id, sort_order)
         VALUES (
           ${reportId},
           ${metric.name},
-          ${metric.value},
-          ${metric.unit || null},
-          ${metric.ref_low ?? null},
-          ${metric.ref_high ?? null},
-          ${flag}
+          ${processed.value},
+          ${processed.unit},
+          ${processed.refLow},
+          ${processed.refHigh},
+          ${processed.flag},
+          ${processed.definitionId},
+          ${i}
         )
         ON CONFLICT (report_id, name) DO UPDATE
         SET value = EXCLUDED.value,
             unit = COALESCE(EXCLUDED.unit, metrics.unit),
             ref_low = COALESCE(EXCLUDED.ref_low, metrics.ref_low),
             ref_high = COALESCE(EXCLUDED.ref_high, metrics.ref_high),
-            flag = EXCLUDED.flag
+            flag = EXCLUDED.flag,
+            metric_definition_id = COALESCE(EXCLUDED.metric_definition_id, metrics.metric_definition_id),
+            sort_order = EXCLUDED.sort_order
       `;
       insertedCount++;
+    }
 
-      // Ensure metric_preferences row exists
+    // Batch-insert metric_preferences for all confirmed metrics
+    const validNames = validMetrics.map((m) => m.name);
+    if (validNames.length > 0) {
       await sql`
         INSERT INTO metric_preferences (profile_id, name)
-        VALUES (${profileId}, ${metric.name})
+        SELECT ${profileId}, unnest(${validNames}::text[])
         ON CONFLICT (profile_id, name) DO NOTHING
       `;
     }
@@ -207,6 +222,20 @@ export async function POST(
         importId: id,
       });
     }
+
+    // Track unmapped metrics (fire-and-forget)
+    const unmappedData = processedMetrics.map((p, i) => ({
+      name: validMetrics[i].name,
+      unit: validMetrics[i].unit,
+      refLow: validMetrics[i].ref_low,
+      refHigh: validMetrics[i].ref_high,
+      resolved: p.resolved,
+    }));
+    trackUnmappedMetrics(unmappedData, {
+      reportId,
+      profileId,
+      uploadId: null,
+    });
 
     // Mark pending import as confirmed
     await sql`

--- a/web/src/app/api/settings/files/[id]/metrics/route.ts
+++ b/web/src/app/api/settings/files/[id]/metrics/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, getProfileAccessLevel } from "@/lib/auth";
 import { sql } from "@/lib/db";
 import { reportError } from "@/lib/error-reporting";
 import { isValidUUID } from "@/lib/utils";
+import { processMetric } from "@/lib/metric-definitions";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -86,9 +87,9 @@ export async function PUT(
       );
     }
 
-    // Verify the metric belongs to a report associated with this file
+    // Verify the metric belongs to a report associated with this file and get its name
     const metricCheck = await sql`
-      SELECT m.id
+      SELECT m.id, m.name
       FROM metrics m
       JOIN reports r ON r.id = m.report_id
       WHERE m.id = ${body.metricId}
@@ -106,25 +107,27 @@ export async function PUT(
       );
     }
 
-    // Calculate flag based on reference values
-    let flag: string | null = null;
-    if (body.ref_low != null && body.value < body.ref_low) {
-      flag = "L";
-    } else if (body.ref_high != null && body.value > body.ref_high) {
-      flag = "H";
-    } else if (body.ref_low != null || body.ref_high != null) {
-      flag = "N";
-    }
+    const existingMetric = metricCheck[0];
 
-    // Update the metric
+    // Re-process through the unified pipeline to handle unit conversion and flag calculation
+    const processed = await processMetric({
+      name: existingMetric.name as string,
+      value: body.value,
+      unit: body.unit,
+      ref_low: body.ref_low,
+      ref_high: body.ref_high,
+    });
+
+    // Update the metric with processed values
     await sql`
       UPDATE metrics
       SET
-        value = ${body.value},
-        unit = ${body.unit},
-        ref_low = ${body.ref_low},
-        ref_high = ${body.ref_high},
-        flag = ${flag}
+        value = ${processed.value},
+        unit = ${processed.unit},
+        ref_low = ${processed.refLow},
+        ref_high = ${processed.refHigh},
+        flag = ${processed.flag},
+        metric_definition_id = COALESCE(${processed.definitionId}, metric_definition_id)
       WHERE id = ${body.metricId}
     `;
 

--- a/web/src/app/api/upload/[id]/confirm/route.ts
+++ b/web/src/app/api/upload/[id]/confirm/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { sql } from "@/lib/db";
 import { reportError } from "@/lib/error-reporting";
-import { resolveMetricName, convertUnit } from "@/lib/metric-definitions";
+import {
+  processMetricsBatch,
+  trackUnmappedMetrics,
+  type RawMetric,
+} from "@/lib/metric-definitions";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,17 +26,6 @@ interface ConfirmRequest {
 
 function isValidMetricValue(value: unknown): value is number {
   return typeof value === "number" && !isNaN(value);
-}
-
-function determineFlag(
-  value: number,
-  refLow: number | null | undefined,
-  refHigh: number | null | undefined,
-): string | null {
-  if (refLow != null && value < refLow) return "L";
-  if (refHigh != null && value > refHigh) return "H";
-  if (refLow != null || refHigh != null) return "N";
-  return null;
 }
 
 /**
@@ -154,57 +147,44 @@ export async function POST(
       `[API] Created new report: ${reportId} for date ${body.sampleDate}`,
     );
 
+    // Filter valid metrics and process through unified pipeline
+    const validMetrics = body.metrics.filter((m) => {
+      if (!isValidMetricValue(m.value)) {
+        console.log(`[API] Skipping metric with invalid value: ${m.name}`);
+        return false;
+      }
+      return true;
+    });
+
+    // Process all metrics through the unified pipeline (resolve + convert + flag)
+    const rawMetrics: RawMetric[] = validMetrics.map((m) => ({
+      name: m.name,
+      value: m.value,
+      unit: m.unit,
+      ref_low: m.ref_low,
+      ref_high: m.ref_high,
+    }));
+    const processedMetrics = await processMetricsBatch(rawMetrics);
+
     // Insert metrics
     let insertedCount = 0;
     let updatedCount = 0;
 
-    // Resolve all metric names + unit conversions in parallel
-    const resolutions = await Promise.all(
-      body.metrics.map(async (metric) => {
-        if (!isValidMetricValue(metric.value)) return null;
-        const resolution = await resolveMetricName(metric.name);
-        let conversion = null;
-        if (resolution && metric.unit) {
-          conversion = await convertUnit(
-            resolution.definitionId,
-            metric.value,
-            metric.unit,
-          );
-        }
-        return { resolution, conversion };
-      }),
-    );
+    for (let i = 0; i < processedMetrics.length; i++) {
+      const metric = validMetrics[i];
+      const processed = processedMetrics[i];
 
-    for (let i = 0; i < body.metrics.length; i++) {
-      const metric = body.metrics[i];
-      if (!isValidMetricValue(metric.value)) {
-        console.log(`[API] Skipping metric with invalid value: ${metric.name}`);
-        continue;
-      }
-
-      const { resolution, conversion } = resolutions[i] ?? {};
-      let finalValue = metric.value;
-      let finalUnit = metric.unit || null;
-
-      if (conversion?.converted) {
-        finalValue = conversion.value;
-        finalUnit = conversion.unit;
-      }
-
-      const flag = determineFlag(finalValue, metric.ref_low, metric.ref_high);
-
-      // Insert or update metric
       const result = await sql`
         INSERT INTO metrics (report_id, name, value, unit, ref_low, ref_high, flag, metric_definition_id, sort_order)
         VALUES (
           ${reportId},
           ${metric.name},
-          ${finalValue},
-          ${finalUnit},
-          ${metric.ref_low ?? null},
-          ${metric.ref_high ?? null},
-          ${flag},
-          ${resolution?.definitionId ?? null},
+          ${processed.value},
+          ${processed.unit},
+          ${processed.refLow},
+          ${processed.refHigh},
+          ${processed.flag},
+          ${processed.definitionId},
           ${i}
         )
         ON CONFLICT (report_id, name) DO UPDATE
@@ -227,9 +207,7 @@ export async function POST(
     }
 
     // Batch-insert metric_preferences for all confirmed metrics
-    const validNames = body.metrics
-      .filter((m) => isValidMetricValue(m.value))
-      .map((m) => m.name);
+    const validNames = validMetrics.map((m) => m.name);
     if (validNames.length > 0) {
       await sql`
         INSERT INTO metric_preferences (profile_id, name)
@@ -251,24 +229,19 @@ export async function POST(
       reportError(e, { op: "upload.confirm.processedFiles", uploadId });
     }
 
-    // Detect unmapped metrics (fire-and-forget — don't block confirm flow)
-    try {
-      for (let i = 0; i < body.metrics.length; i++) {
-        const metric = body.metrics[i];
-        if (!isValidMetricValue(metric.value)) continue;
-
-        // Already resolved = not unmapped
-        if (resolutions[i]?.resolution) continue;
-
-        await sql`
-          INSERT INTO unmapped_metrics (metric_name, unit, ref_low, ref_high, report_id, profile_id, upload_id, status)
-          VALUES (${metric.name}, ${metric.unit || null}, ${metric.ref_low ?? null}, ${metric.ref_high ?? null}, ${reportId}, ${profileId}, ${uploadId}, 'pending')
-          ON CONFLICT (report_id, metric_name) DO NOTHING
-        `;
-      }
-    } catch (e) {
-      reportError(e, { op: "upload.confirm.unmappedMetrics", uploadId });
-    }
+    // Track unmapped metrics (fire-and-forget — don't block confirm flow)
+    const unmappedData = processedMetrics.map((p, i) => ({
+      name: validMetrics[i].name,
+      unit: validMetrics[i].unit,
+      refLow: validMetrics[i].ref_low,
+      refHigh: validMetrics[i].ref_high,
+      resolved: p.resolved,
+    }));
+    trackUnmappedMetrics(unmappedData, {
+      reportId,
+      profileId,
+      uploadId,
+    });
 
     // Update pending upload status — blob is preserved for admin review and re-extraction
     await sql`

--- a/web/src/lib/metric-definitions.ts
+++ b/web/src/lib/metric-definitions.ts
@@ -24,7 +24,32 @@ export interface UnitConversionResult {
   value: number;
   unit: string;
   converted: boolean;
+  factor?: number;
   description?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Unified Metric Processing Types
+// ---------------------------------------------------------------------------
+
+export interface RawMetric {
+  name: string;
+  value: number;
+  unit?: string | null;
+  ref_low?: number | null;
+  ref_high?: number | null;
+}
+
+export interface ProcessedMetric {
+  name: string; // Canonical or original
+  value: number; // Converted
+  unit: string | null; // Canonical or original
+  refLow: number | null; // Converted
+  refHigh: number | null; // Converted
+  flag: "H" | "L" | "N" | null;
+  definitionId: string | null;
+  resolved: boolean;
+  converted: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -394,6 +419,7 @@ export async function convertUnit(
     value: convertedValue,
     unit: targetUnit,
     converted: true,
+    factor,
     description: `${fromUnit} \u2192 ${targetUnit} (\u00D7 ${factor})`,
   };
 }
@@ -416,4 +442,126 @@ export async function getAliasMap(): Promise<
   }
 
   return map;
+}
+
+// ---------------------------------------------------------------------------
+// Unified Metric Processing
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine flag based on value and reference range.
+ * Returns 'H' if high, 'L' if low, 'N' if normal, null if no ref range.
+ */
+export function determineFlag(
+  value: number,
+  refLow: number | null | undefined,
+  refHigh: number | null | undefined,
+): "H" | "L" | "N" | null {
+  if (refLow != null && value < refLow) return "L";
+  if (refHigh != null && value > refHigh) return "H";
+  if (refLow != null || refHigh != null) return "N";
+  return null;
+}
+
+/**
+ * Process a single metric through the full pipeline:
+ * 1. Resolve name to canonical form + definition ID
+ * 2. Convert unit (and apply conversion factor to ref ranges)
+ * 3. Calculate flag based on converted values
+ */
+export async function processMetric(raw: RawMetric): Promise<ProcessedMetric> {
+  // Step 1: Resolve metric name
+  const resolution = await resolveMetricName(raw.name);
+  const definitionId = resolution?.definitionId ?? null;
+  const resolved = !!resolution;
+
+  // Step 2: Convert unit if we have a definition and unit
+  let finalValue = raw.value;
+  let finalUnit = raw.unit ?? null;
+  let finalRefLow = raw.ref_low ?? null;
+  let finalRefHigh = raw.ref_high ?? null;
+  let converted = false;
+
+  if (definitionId && raw.unit) {
+    const conversion = await convertUnit(definitionId, raw.value, raw.unit);
+    if (conversion.converted && conversion.factor) {
+      finalValue = conversion.value;
+      finalUnit = conversion.unit;
+      converted = true;
+      // Apply same conversion factor to reference range
+      if (finalRefLow != null) {
+        finalRefLow = Number((finalRefLow * conversion.factor).toFixed(2));
+      }
+      if (finalRefHigh != null) {
+        finalRefHigh = Number((finalRefHigh * conversion.factor).toFixed(2));
+      }
+    } else {
+      // No conversion needed, but normalize unit
+      finalUnit = conversion.unit;
+    }
+  }
+
+  // Step 3: Calculate flag
+  const flag = determineFlag(finalValue, finalRefLow, finalRefHigh);
+
+  return {
+    name: raw.name, // Keep original name (alias resolution is for definition lookup only)
+    value: finalValue,
+    unit: finalUnit,
+    refLow: finalRefLow,
+    refHigh: finalRefHigh,
+    flag,
+    definitionId,
+    resolved,
+    converted,
+  };
+}
+
+/**
+ * Process a batch of metrics in parallel.
+ * Warms up caches first to avoid repeated DB queries.
+ */
+export async function processMetricsBatch(
+  metrics: RawMetric[],
+): Promise<ProcessedMetric[]> {
+  // Warm up caches before parallel processing
+  await Promise.all([loadAliases(), loadTranslations(), loadUnitAliases()]);
+
+  // Process all metrics in parallel
+  return Promise.all(metrics.map(processMetric));
+}
+
+/**
+ * Track unmapped metrics (fire-and-forget).
+ * Does not throw on failure - logs errors internally.
+ */
+export async function trackUnmappedMetrics(
+  metrics: Array<{
+    name: string;
+    unit?: string | null;
+    refLow?: number | null;
+    refHigh?: number | null;
+    resolved: boolean;
+  }>,
+  context: {
+    reportId: string;
+    profileId: string;
+    uploadId?: string | null;
+  },
+): Promise<void> {
+  try {
+    const unmapped = metrics.filter((m) => !m.resolved);
+    if (unmapped.length === 0) return;
+
+    for (const m of unmapped) {
+      await sql`
+        INSERT INTO unmapped_metrics (metric_name, unit, ref_low, ref_high, report_id, profile_id, upload_id, status)
+        VALUES (${m.name}, ${m.unit || null}, ${m.refLow ?? null}, ${m.refHigh ?? null}, ${context.reportId}, ${context.profileId}, ${context.uploadId || null}, 'pending')
+        ON CONFLICT (report_id, metric_name) DO NOTHING
+      `;
+    }
+  } catch (e) {
+    // Fire-and-forget - don't block the main flow
+    console.error("[trackUnmappedMetrics] Error:", e);
+  }
 }


### PR DESCRIPTION
PDF upload, e-Nabız import, manual edits, and admin corrections now share the same processMetric() pipeline — ensuring consistent name resolution, unit conversion, flag calculation, and definition_id assignment.