### PR TITLE
feat: add admin metric definitions CRUD page

### DIFF
--- a/web/src/app/admin/metric-definitions/page.tsx
+++ b/web/src/app/admin/metric-definitions/page.tsx
@@ -1,0 +1,1060 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronLeft,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+  Check,
+  Search,
+} from "lucide-react";
+
+interface MetricDefinition {
+  id: string;
+  key: string;
+  category: string | null;
+  canonical_unit: string | null;
+  value_type: string;
+  created_at: string;
+  translation_count: number;
+  alias_count: number;
+  ref_range_count: number;
+}
+
+interface Translation {
+  id: string;
+  locale: string;
+  display_name: string;
+}
+
+interface Alias {
+  id: string;
+  alias: string;
+  canonical_name: string;
+}
+
+interface RefRange {
+  id: string;
+  sex: string | null;
+  age_min: number | null;
+  age_max: number | null;
+  ref_low: number | null;
+  ref_high: number | null;
+}
+
+interface ExpandedData {
+  translations: Translation[];
+  aliases: Alias[];
+  refRanges: RefRange[];
+}
+
+type ActiveTab = "translations" | "aliases" | "refRanges";
+
+export default function MetricDefinitionsPage() {
+  const [definitions, setDefinitions] = useState<MetricDefinition[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filters
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("");
+
+  // Expanded row state
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedData, setExpandedData] = useState<ExpandedData | null>(null);
+  const [expandedLoading, setExpandedLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState<ActiveTab>("translations");
+
+  // Create/edit modal state
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [editingDefinition, setEditingDefinition] = useState<MetricDefinition | null>(null);
+  const [formData, setFormData] = useState({
+    key: "",
+    category: "",
+    canonicalUnit: "",
+    valueType: "quantitative",
+  });
+  const [formLoading, setFormLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Inline add state
+  const [addingTranslation, setAddingTranslation] = useState(false);
+  const [newTranslation, setNewTranslation] = useState({ locale: "", displayName: "" });
+  const [addingAlias, setAddingAlias] = useState(false);
+  const [newAlias, setNewAlias] = useState("");
+  const [addingRefRange, setAddingRefRange] = useState(false);
+  const [newRefRange, setNewRefRange] = useState({
+    sex: "",
+    ageMin: "",
+    ageMax: "",
+    refLow: "",
+    refHigh: "",
+  });
+
+  // Editing translation state
+  const [editingTranslation, setEditingTranslation] = useState<Translation | null>(null);
+  const [editTranslationData, setEditTranslationData] = useState({ locale: "", displayName: "" });
+
+  // Editing ref range state
+  const [editingRefRange, setEditingRefRange] = useState<RefRange | null>(null);
+  const [editRefRangeData, setEditRefRangeData] = useState({
+    sex: "",
+    ageMin: "",
+    ageMax: "",
+    refLow: "",
+    refHigh: "",
+  });
+
+  const fetchDefinitions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (searchQuery) params.set("search", searchQuery);
+      if (selectedCategory) params.set("category", selectedCategory);
+
+      const res = await fetch(`/api/admin/metric-definitions?${params}`);
+      if (!res.ok) throw new Error("Failed to fetch");
+      const data = await res.json();
+      setDefinitions(data.items);
+      setCategories(data.categories || []);
+    } catch {
+      setError("Failed to load metric definitions");
+    } finally {
+      setLoading(false);
+    }
+  }, [searchQuery, selectedCategory]);
+
+  useEffect(() => {
+    fetchDefinitions();
+  }, [fetchDefinitions]);
+
+  const fetchExpandedData = async (id: string) => {
+    setExpandedLoading(true);
+    try {
+      const res = await fetch(`/api/admin/metric-definitions/${id}`);
+      if (!res.ok) throw new Error("Failed to fetch");
+      const data = await res.json();
+      setExpandedData({
+        translations: data.translations,
+        aliases: data.aliases,
+        refRanges: data.refRanges,
+      });
+    } catch {
+      setExpandedData(null);
+    } finally {
+      setExpandedLoading(false);
+    }
+  };
+
+  const handleExpand = (id: string) => {
+    if (expandedId === id) {
+      setExpandedId(null);
+      setExpandedData(null);
+    } else {
+      setExpandedId(id);
+      setActiveTab("translations");
+      fetchExpandedData(id);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this metric definition and all related data?")) return;
+    try {
+      const res = await fetch(`/api/admin/metric-definitions/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to delete");
+      fetchDefinitions();
+      if (expandedId === id) {
+        setExpandedId(null);
+        setExpandedData(null);
+      }
+    } catch {
+      alert("Failed to delete metric definition");
+    }
+  };
+
+  const handleCreateOrUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormLoading(true);
+    setFormError(null);
+
+    try {
+      const url = editingDefinition
+        ? `/api/admin/metric-definitions/${editingDefinition.id}`
+        : "/api/admin/metric-definitions";
+      const method = editingDefinition ? "PUT" : "POST";
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to save");
+      }
+
+      setShowCreateModal(false);
+      setEditingDefinition(null);
+      setFormData({ key: "", category: "", canonicalUnit: "", valueType: "quantitative" });
+      fetchDefinitions();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  const openEditModal = (def: MetricDefinition) => {
+    setEditingDefinition(def);
+    setFormData({
+      key: def.key,
+      category: def.category || "",
+      canonicalUnit: def.canonical_unit || "",
+      valueType: def.value_type,
+    });
+    setShowCreateModal(true);
+  };
+
+  const closeModal = () => {
+    setShowCreateModal(false);
+    setEditingDefinition(null);
+    setFormData({ key: "", category: "", canonicalUnit: "", valueType: "quantitative" });
+    setFormError(null);
+  };
+
+  // Sub-resource handlers
+  const addTranslation = async () => {
+    if (!expandedId || !newTranslation.locale || !newTranslation.displayName) return;
+    try {
+      const res = await fetch(`/api/admin/metric-definitions/${expandedId}/translations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newTranslation),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to add");
+      }
+      setAddingTranslation(false);
+      setNewTranslation({ locale: "", displayName: "" });
+      fetchExpandedData(expandedId);
+      fetchDefinitions();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to add translation");
+    }
+  };
+
+  const updateTranslation = async () => {
+    if (!expandedId || !editingTranslation) return;
+    try {
+      const res = await fetch(
+        `/api/admin/metric-definitions/${expandedId}/translations/${editingTranslation.id}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            locale: editTranslationData.locale,
+            displayName: editTranslationData.displayName,
+          }),
+        }
+      );
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to update");
+      }
+      setEditingTranslation(null);
+      fetchExpandedData(expandedId);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update translation");
+    }
+  };
+
+  const deleteTranslation = async (translationId: string) => {
+    if (!expandedId) return;
+    if (!confirm("Delete this translation?")) return;
+    try {
+      const res = await fetch(
+        `/api/admin/metric-definitions/${expandedId}/translations/${translationId}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) throw new Error("Failed to delete");
+      fetchExpandedData(expandedId);
+      fetchDefinitions();
+    } catch {
+      alert("Failed to delete translation");
+    }
+  };
+
+  const addAlias = async () => {
+    if (!expandedId || !newAlias) return;
+    try {
+      const res = await fetch(`/api/admin/metric-definitions/${expandedId}/aliases`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ alias: newAlias }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to add");
+      }
+      setAddingAlias(false);
+      setNewAlias("");
+      fetchExpandedData(expandedId);
+      fetchDefinitions();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to add alias");
+    }
+  };
+
+  const deleteAlias = async (aliasId: string) => {
+    if (!expandedId) return;
+    if (!confirm("Delete this alias?")) return;
+    try {
+      const res = await fetch(
+        `/api/admin/metric-definitions/${expandedId}/aliases/${aliasId}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) throw new Error("Failed to delete");
+      fetchExpandedData(expandedId);
+      fetchDefinitions();
+    } catch {
+      alert("Failed to delete alias");
+    }
+  };
+
+  const addRefRange = async () => {
+    if (!expandedId) return;
+    const { sex, ageMin, ageMax, refLow, refHigh } = newRefRange;
+    if (!refLow && !refHigh) {
+      alert("At least one of refLow or refHigh is required");
+      return;
+    }
+    try {
+      const res = await fetch(`/api/admin/metric-definitions/${expandedId}/ref-ranges`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sex: sex || null,
+          ageMin: ageMin ? parseInt(ageMin) : null,
+          ageMax: ageMax ? parseInt(ageMax) : null,
+          refLow: refLow ? parseFloat(refLow) : null,
+          refHigh: refHigh ? parseFloat(refHigh) : null,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to add");
+      }
+      setAddingRefRange(false);
+      setNewRefRange({ sex: "", ageMin: "", ageMax: "", refLow: "", refHigh: "" });
+      fetchExpandedData(expandedId);
+      fetchDefinitions();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to add reference range");
+    }
+  };
+
+  const updateRefRange = async () => {
+    if (!expandedId || !editingRefRange) return;
+    const { sex, ageMin, ageMax, refLow, refHigh } = editRefRangeData;
+    try {
+      const res = await fetch(
+        `/api/admin/metric-definitions/${expandedId}/ref-ranges/${editingRefRange.id}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sex: sex || null,
+            ageMin: ageMin ? parseInt(ageMin) : null,
+            ageMax: ageMax ? parseInt(ageMax) : null,
+            refLow: refLow ? parseFloat(refLow) : null,
+            refHigh: refHigh ? parseFloat(refHigh) : null,
+          }),
+        }
+      );
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to update");
+      }
+      setEditingRefRange(null);
+      fetchExpandedData(expandedId);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update reference range");
+    }
+  };
+
+  const deleteRefRange = async (rangeId: string) => {
+    if (!expandedId) return;
+    if (!confirm("Delete this reference range?")) return;
+    try {
+      const res = await fetch(
+        `/api/admin/metric-definitions/${expandedId}/ref-ranges/${rangeId}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) throw new Error("Failed to delete");
+      fetchExpandedData(expandedId);
+      fetchDefinitions();
+    } catch {
+      alert("Failed to delete reference range");
+    }
+  };
+
+  const startEditTranslation = (t: Translation) => {
+    setEditingTranslation(t);
+    setEditTranslationData({ locale: t.locale, displayName: t.display_name });
+  };
+
+  const startEditRefRange = (r: RefRange) => {
+    setEditingRefRange(r);
+    setEditRefRangeData({
+      sex: r.sex || "",
+      ageMin: r.age_min?.toString() || "",
+      ageMax: r.age_max?.toString() || "",
+      refLow: r.ref_low?.toString() || "",
+      refHigh: r.ref_high?.toString() || "",
+    });
+  };
+
+  return (
+    <main className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link href="/admin" className="hover:text-foreground flex items-center gap-1">
+          <ChevronLeft className="size-4" />
+          Admin
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">Metric Definitions</span>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Metric Definitions</h1>
+        <Button onClick={() => setShowCreateModal(true)}>
+          <Plus className="size-4 mr-2" />
+          Add Definition
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search by key..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+            <select
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value)}
+              className="h-10 px-3 rounded-md border border-input bg-background text-sm"
+            >
+              <option value="">All Categories</option>
+              {categories.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* List */}
+      <Card>
+        <CardContent className="pt-6">
+          {loading ? (
+            <div className="space-y-3">
+              {[...Array(5)].map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : error ? (
+            <p className="text-destructive">{error}</p>
+          ) : definitions.length === 0 ? (
+            <p className="text-muted-foreground text-center py-8">
+              No metric definitions found.
+            </p>
+          ) : (
+            <div className="divide-y">
+              {definitions.map((def) => (
+                <div key={def.id}>
+                  {/* Main row */}
+                  <div
+                    className="flex items-center gap-4 py-3 hover:bg-muted/50 px-2 -mx-2 rounded cursor-pointer"
+                    onClick={() => handleExpand(def.id)}
+                  >
+                    <div className="text-muted-foreground">
+                      {expandedId === def.id ? (
+                        <ChevronDown className="size-4" />
+                      ) : (
+                        <ChevronRight className="size-4" />
+                      )}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium">{def.key}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {def.category || "No category"}
+                      </div>
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {def.canonical_unit || "-"}
+                    </div>
+                    <Badge variant="outline">{def.value_type}</Badge>
+                    <div className="flex gap-2">
+                      <Badge variant="secondary">{def.translation_count} trans</Badge>
+                      <Badge variant="secondary">{def.alias_count} alias</Badge>
+                      <Badge variant="secondary">{def.ref_range_count} ranges</Badge>
+                    </div>
+                    <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEditModal(def)}
+                      >
+                        <Pencil className="size-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDelete(def.id)}
+                      >
+                        <Trash2 className="size-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* Expanded content */}
+                  {expandedId === def.id && (
+                    <div className="pb-4 pl-8 pr-2">
+                      {/* Tabs */}
+                      <div className="flex gap-2 mb-4 border-b">
+                        {(["translations", "aliases", "refRanges"] as ActiveTab[]).map(
+                          (tab) => (
+                            <button
+                              key={tab}
+                              onClick={() => setActiveTab(tab)}
+                              className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                                activeTab === tab
+                                  ? "border-primary text-primary"
+                                  : "border-transparent text-muted-foreground hover:text-foreground"
+                              }`}
+                            >
+                              {tab === "translations"
+                                ? "Translations"
+                                : tab === "aliases"
+                                ? "Aliases"
+                                : "Reference Ranges"}
+                            </button>
+                          )
+                        )}
+                      </div>
+
+                      {expandedLoading ? (
+                        <div className="space-y-2">
+                          <Skeleton className="h-8 w-full" />
+                          <Skeleton className="h-8 w-full" />
+                        </div>
+                      ) : !expandedData ? (
+                        <p className="text-muted-foreground">Failed to load data</p>
+                      ) : (
+                        <>
+                          {/* Translations tab */}
+                          {activeTab === "translations" && (
+                            <div className="space-y-2">
+                              {expandedData.translations.length === 0 && !addingTranslation && (
+                                <p className="text-sm text-muted-foreground">
+                                  No translations yet.
+                                </p>
+                              )}
+                              {expandedData.translations.map((t) =>
+                                editingTranslation?.id === t.id ? (
+                                  <div
+                                    key={t.id}
+                                    className="flex items-center gap-2 bg-muted/50 p-2 rounded"
+                                  >
+                                    <Input
+                                      value={editTranslationData.locale}
+                                      onChange={(e) =>
+                                        setEditTranslationData({
+                                          ...editTranslationData,
+                                          locale: e.target.value,
+                                        })
+                                      }
+                                      placeholder="Locale"
+                                      className="w-20"
+                                    />
+                                    <Input
+                                      value={editTranslationData.displayName}
+                                      onChange={(e) =>
+                                        setEditTranslationData({
+                                          ...editTranslationData,
+                                          displayName: e.target.value,
+                                        })
+                                      }
+                                      placeholder="Display name"
+                                      className="flex-1"
+                                    />
+                                    <Button size="icon" variant="ghost" onClick={updateTranslation}>
+                                      <Check className="size-4" />
+                                    </Button>
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      onClick={() => setEditingTranslation(null)}
+                                    >
+                                      <X className="size-4" />
+                                    </Button>
+                                  </div>
+                                ) : (
+                                  <div
+                                    key={t.id}
+                                    className="flex items-center gap-2 text-sm"
+                                  >
+                                    <Badge variant="outline" className="w-12 justify-center">
+                                      {t.locale}
+                                    </Badge>
+                                    <span className="flex-1">{t.display_name}</span>
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      onClick={() => startEditTranslation(t)}
+                                    >
+                                      <Pencil className="size-3" />
+                                    </Button>
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      onClick={() => deleteTranslation(t.id)}
+                                    >
+                                      <Trash2 className="size-3 text-destructive" />
+                                    </Button>
+                                  </div>
+                                )
+                              )}
+                              {addingTranslation ? (
+                                <div className="flex items-center gap-2 bg-muted/50 p-2 rounded">
+                                  <Input
+                                    value={newTranslation.locale}
+                                    onChange={(e) =>
+                                      setNewTranslation({
+                                        ...newTranslation,
+                                        locale: e.target.value,
+                                      })
+                                    }
+                                    placeholder="Locale (e.g., tr)"
+                                    className="w-20"
+                                  />
+                                  <Input
+                                    value={newTranslation.displayName}
+                                    onChange={(e) =>
+                                      setNewTranslation({
+                                        ...newTranslation,
+                                        displayName: e.target.value,
+                                      })
+                                    }
+                                    placeholder="Display name"
+                                    className="flex-1"
+                                  />
+                                  <Button size="icon" variant="ghost" onClick={addTranslation}>
+                                    <Check className="size-4" />
+                                  </Button>
+                                  <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    onClick={() => setAddingTranslation(false)}
+                                  >
+                                    <X className="size-4" />
+                                  </Button>
+                                </div>
+                              ) : (
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => setAddingTranslation(true)}
+                                >
+                                  <Plus className="size-3 mr-1" />
+                                  Add Translation
+                                </Button>
+                              )}
+                            </div>
+                          )}
+
+                          {/* Aliases tab */}
+                          {activeTab === "aliases" && (
+                            <div className="space-y-2">
+                              {expandedData.aliases.length === 0 && !addingAlias && (
+                                <p className="text-sm text-muted-foreground">
+                                  No aliases yet.
+                                </p>
+                              )}
+                              {expandedData.aliases.map((a) => (
+                                <div
+                                  key={a.id}
+                                  className="flex items-center gap-2 text-sm"
+                                >
+                                  <span className="flex-1 font-mono">{a.alias}</span>
+                                  <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    onClick={() => deleteAlias(a.id)}
+                                  >
+                                    <Trash2 className="size-3 text-destructive" />
+                                  </Button>
+                                </div>
+                              ))}
+                              {addingAlias ? (
+                                <div className="flex items-center gap-2 bg-muted/50 p-2 rounded">
+                                  <Input
+                                    value={newAlias}
+                                    onChange={(e) => setNewAlias(e.target.value)}
+                                    placeholder="Alias name"
+                                    className="flex-1"
+                                  />
+                                  <Button size="icon" variant="ghost" onClick={addAlias}>
+                                    <Check className="size-4" />
+                                  </Button>
+                                  <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    onClick={() => setAddingAlias(false)}
+                                  >
+                                    <X className="size-4" />
+                                  </Button>
+                                </div>
+                              ) : (
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => setAddingAlias(true)}
+                                >
+                                  <Plus className="size-3 mr-1" />
+                                  Add Alias
+                                </Button>
+                              )}
+                            </div>
+                          )}
+
+                          {/* Reference Ranges tab */}
+                          {activeTab === "refRanges" && (
+                            <div className="space-y-2">
+                              {expandedData.refRanges.length === 0 && !addingRefRange && (
+                                <p className="text-sm text-muted-foreground">
+                                  No reference ranges yet.
+                                </p>
+                              )}
+                              <div className="text-xs text-muted-foreground grid grid-cols-6 gap-2 px-2">
+                                <span>Sex</span>
+                                <span>Age Min</span>
+                                <span>Age Max</span>
+                                <span>Ref Low</span>
+                                <span>Ref High</span>
+                                <span></span>
+                              </div>
+                              {expandedData.refRanges.map((r) =>
+                                editingRefRange?.id === r.id ? (
+                                  <div
+                                    key={r.id}
+                                    className="grid grid-cols-6 gap-2 bg-muted/50 p-2 rounded"
+                                  >
+                                    <select
+                                      value={editRefRangeData.sex}
+                                      onChange={(e) =>
+                                        setEditRefRangeData({
+                                          ...editRefRangeData,
+                                          sex: e.target.value,
+                                        })
+                                      }
+                                      className="h-8 px-2 rounded border bg-background text-sm"
+                                    >
+                                      <option value="">All</option>
+                                      <option value="M">M</option>
+                                      <option value="F">F</option>
+                                    </select>
+                                    <Input
+                                      type="number"
+                                      value={editRefRangeData.ageMin}
+                                      onChange={(e) =>
+                                        setEditRefRangeData({
+                                          ...editRefRangeData,
+                                          ageMin: e.target.value,
+                                        })
+                                      }
+                                      placeholder="-"
+                                      className="h-8"
+                                    />
+                                    <Input
+                                      type="number"
+                                      value={editRefRangeData.ageMax}
+                                      onChange={(e) =>
+                                        setEditRefRangeData({
+                                          ...editRefRangeData,
+                                          ageMax: e.target.value,
+                                        })
+                                      }
+                                      placeholder="-"
+                                      className="h-8"
+                                    />
+                                    <Input
+                                      type="number"
+                                      step="any"
+                                      value={editRefRangeData.refLow}
+                                      onChange={(e) =>
+                                        setEditRefRangeData({
+                                          ...editRefRangeData,
+                                          refLow: e.target.value,
+                                        })
+                                      }
+                                      placeholder="-"
+                                      className="h-8"
+                                    />
+                                    <Input
+                                      type="number"
+                                      step="any"
+                                      value={editRefRangeData.refHigh}
+                                      onChange={(e) =>
+                                        setEditRefRangeData({
+                                          ...editRefRangeData,
+                                          refHigh: e.target.value,
+                                        })
+                                      }
+                                      placeholder="-"
+                                      className="h-8"
+                                    />
+                                    <div className="flex gap-1">
+                                      <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        onClick={updateRefRange}
+                                      >
+                                        <Check className="size-4" />
+                                      </Button>
+                                      <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        onClick={() => setEditingRefRange(null)}
+                                      >
+                                        <X className="size-4" />
+                                      </Button>
+                                    </div>
+                                  </div>
+                                ) : (
+                                  <div
+                                    key={r.id}
+                                    className="grid grid-cols-6 gap-2 text-sm items-center px-2"
+                                  >
+                                    <span>{r.sex || "All"}</span>
+                                    <span>{r.age_min ?? "-"}</span>
+                                    <span>{r.age_max ?? "-"}</span>
+                                    <span>{r.ref_low ?? "-"}</span>
+                                    <span>{r.ref_high ?? "-"}</span>
+                                    <div className="flex gap-1">
+                                      <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        onClick={() => startEditRefRange(r)}
+                                      >
+                                        <Pencil className="size-3" />
+                                      </Button>
+                                      <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        onClick={() => deleteRefRange(r.id)}
+                                      >
+                                        <Trash2 className="size-3 text-destructive" />
+                                      </Button>
+                                    </div>
+                                  </div>
+                                )
+                              )}
+                              {addingRefRange ? (
+                                <div className="grid grid-cols-6 gap-2 bg-muted/50 p-2 rounded">
+                                  <select
+                                    value={newRefRange.sex}
+                                    onChange={(e) =>
+                                      setNewRefRange({ ...newRefRange, sex: e.target.value })
+                                    }
+                                    className="h-8 px-2 rounded border bg-background text-sm"
+                                  >
+                                    <option value="">All</option>
+                                    <option value="M">M</option>
+                                    <option value="F">F</option>
+                                  </select>
+                                  <Input
+                                    type="number"
+                                    value={newRefRange.ageMin}
+                                    onChange={(e) =>
+                                      setNewRefRange({ ...newRefRange, ageMin: e.target.value })
+                                    }
+                                    placeholder="Age min"
+                                    className="h-8"
+                                  />
+                                  <Input
+                                    type="number"
+                                    value={newRefRange.ageMax}
+                                    onChange={(e) =>
+                                      setNewRefRange({ ...newRefRange, ageMax: e.target.value })
+                                    }
+                                    placeholder="Age max"
+                                    className="h-8"
+                                  />
+                                  <Input
+                                    type="number"
+                                    step="any"
+                                    value={newRefRange.refLow}
+                                    onChange={(e) =>
+                                      setNewRefRange({ ...newRefRange, refLow: e.target.value })
+                                    }
+                                    placeholder="Ref low"
+                                    className="h-8"
+                                  />
+                                  <Input
+                                    type="number"
+                                    step="any"
+                                    value={newRefRange.refHigh}
+                                    onChange={(e) =>
+                                      setNewRefRange({ ...newRefRange, refHigh: e.target.value })
+                                    }
+                                    placeholder="Ref high"
+                                    className="h-8"
+                                  />
+                                  <div className="flex gap-1">
+                                    <Button size="icon" variant="ghost" onClick={addRefRange}>
+                                      <Check className="size-4" />
+                                    </Button>
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      onClick={() => setAddingRefRange(false)}
+                                    >
+                                      <X className="size-4" />
+                                    </Button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => setAddingRefRange(true)}
+                                >
+                                  <Plus className="size-3 mr-1" />
+                                  Add Reference Range
+                                </Button>
+                              )}
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create/Edit Modal */}
+      {showCreateModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <Card className="w-full max-w-md">
+            <CardHeader>
+              <CardTitle>
+                {editingDefinition ? "Edit Metric Definition" : "Add Metric Definition"}
+              </CardTitle>
+              <CardDescription>
+                {editingDefinition
+                  ? "Update the metric definition details."
+                  : "Create a new metric definition."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleCreateOrUpdate} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="key">Key (slug)</Label>
+                  <Input
+                    id="key"
+                    value={formData.key}
+                    onChange={(e) => setFormData({ ...formData, key: e.target.value })}
+                    placeholder="e.g., hemoglobin"
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="category">Category</Label>
+                  <Input
+                    id="category"
+                    value={formData.category}
+                    onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+                    placeholder="e.g., CBC"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="canonicalUnit">Canonical Unit</Label>
+                  <Input
+                    id="canonicalUnit"
+                    value={formData.canonicalUnit}
+                    onChange={(e) =>
+                      setFormData({ ...formData, canonicalUnit: e.target.value })
+                    }
+                    placeholder="e.g., g/dL"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="valueType">Value Type</Label>
+                  <select
+                    id="valueType"
+                    value={formData.valueType}
+                    onChange={(e) => setFormData({ ...formData, valueType: e.target.value })}
+                    className="w-full h-10 px-3 rounded-md border border-input bg-background text-sm"
+                  >
+                    <option value="quantitative">Quantitative</option>
+                    <option value="qualitative">Qualitative</option>
+                  </select>
+                </div>
+                {formError && <p className="text-sm text-destructive">{formError}</p>}
+                <div className="flex justify-end gap-2">
+                  <Button type="button" variant="outline" onClick={closeModal}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={formLoading}>
+                    {formLoading ? "Saving..." : "Save"}
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { Card, CardContent, CardDescription, CardTitle } from "@/components/ui/card";
+import { FileSearch, Database } from "lucide-react";
+
+export default function AdminPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-6 py-8 space-y-8">
+      <h1 className="text-2xl font-semibold">Admin</h1>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Link href="/admin/quality">
+          <Card className="py-6 hover:bg-muted/50 transition-colors cursor-pointer">
+            <CardContent className="flex items-start gap-4">
+              <div className="rounded-lg bg-primary/10 p-2">
+                <FileSearch className="size-5 text-primary" aria-hidden="true" />
+              </div>
+              <div>
+                <CardTitle className="text-base">Report Reviews</CardTitle>
+                <CardDescription className="mt-1">
+                  Review extraction quality and approve reports
+                </CardDescription>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/admin/metric-definitions">
+          <Card className="py-6 hover:bg-muted/50 transition-colors cursor-pointer">
+            <CardContent className="flex items-start gap-4">
+              <div className="rounded-lg bg-primary/10 p-2">
+                <Database className="size-5 text-primary" aria-hidden="true" />
+              </div>
+              <div>
+                <CardTitle className="text-base">Metric Definitions</CardTitle>
+                <CardDescription className="mt-1">
+                  Manage metrics, translations, aliases, and reference ranges
+                </CardDescription>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/api/admin/metric-definitions/[id]/aliases/[aliasId]/route.ts
+++ b/web/src/app/api/admin/metric-definitions/[id]/aliases/[aliasId]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+import { isValidUUID } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * DELETE /api/admin/metric-definitions/[id]/aliases/[aliasId]
+ * Delete an alias.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; aliasId: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id, aliasId } = await params;
+
+    if (!isValidUUID(id) || !isValidUUID(aliasId)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify alias exists and belongs to this definition
+    const existing = await sql`
+      SELECT id FROM metric_aliases
+      WHERE id = ${aliasId} AND metric_definition_id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await sql`DELETE FROM metric_aliases WHERE id = ${aliasId}`;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    reportError(error, { op: "admin.metric-definitions.aliases.DELETE" });
+    return NextResponse.json(
+      { error: "Failed to delete alias" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/metric-definitions/[id]/aliases/route.ts
+++ b/web/src/app/api/admin/metric-definitions/[id]/aliases/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+import { isValidUUID } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/metric-definitions/[id]/aliases
+ * Add an alias for a metric definition.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id } = await params;
+
+    if (!isValidUUID(id)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify definition exists and get key for canonical_name
+    const definition = await sql`
+      SELECT id, key FROM metric_definitions WHERE id = ${id}
+    `;
+    if (definition.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { alias } = body;
+
+    if (!alias || typeof alias !== "string" || alias.length > 200) {
+      return NextResponse.json(
+        { error: "alias is required and must be <= 200 characters" },
+        { status: 400 },
+      );
+    }
+
+    const result = await sql`
+      INSERT INTO metric_aliases (alias, canonical_name, metric_definition_id)
+      VALUES (${alias}, ${definition[0].key}, ${id})
+      RETURNING id
+    `;
+
+    return NextResponse.json({ id: result[0].id }, { status: 201 });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: "This alias already exists" },
+        { status: 409 },
+      );
+    }
+    reportError(error, { op: "admin.metric-definitions.aliases.POST" });
+    return NextResponse.json(
+      { error: "Failed to create alias" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/metric-definitions/[id]/ref-ranges/[rangeId]/route.ts
+++ b/web/src/app/api/admin/metric-definitions/[id]/ref-ranges/[rangeId]/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+import { isValidUUID } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * PUT /api/admin/metric-definitions/[id]/ref-ranges/[rangeId]
+ * Update a reference range.
+ */
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string; rangeId: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id, rangeId } = await params;
+
+    if (!isValidUUID(id) || !isValidUUID(rangeId)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify ref range exists and belongs to this definition
+    const existing = await sql`
+      SELECT id FROM metric_ref_ranges
+      WHERE id = ${rangeId} AND metric_definition_id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { sex, ageMin, ageMax, refLow, refHigh } = body;
+
+    // Validate sex if provided
+    if (sex !== undefined && sex !== null && !["M", "F"].includes(sex)) {
+      return NextResponse.json(
+        { error: "sex must be null, 'M', or 'F'" },
+        { status: 400 },
+      );
+    }
+
+    await sql`
+      UPDATE metric_ref_ranges
+      SET
+        sex = ${sex === undefined ? null : (sex || null)},
+        age_min = ${ageMin === undefined ? null : (ageMin ?? null)},
+        age_max = ${ageMax === undefined ? null : (ageMax ?? null)},
+        ref_low = ${refLow === undefined ? null : (refLow ?? null)},
+        ref_high = ${refHigh === undefined ? null : (refHigh ?? null)}
+      WHERE id = ${rangeId}
+    `;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: "A reference range with these parameters already exists" },
+        { status: 409 },
+      );
+    }
+    reportError(error, { op: "admin.metric-definitions.ref-ranges.PUT" });
+    return NextResponse.json(
+      { error: "Failed to update reference range" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/metric-definitions/[id]/ref-ranges/[rangeId]
+ * Delete a reference range.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; rangeId: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id, rangeId } = await params;
+
+    if (!isValidUUID(id) || !isValidUUID(rangeId)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify ref range exists and belongs to this definition
+    const existing = await sql`
+      SELECT id FROM metric_ref_ranges
+      WHERE id = ${rangeId} AND metric_definition_id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await sql`DELETE FROM metric_ref_ranges WHERE id = ${rangeId}`;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    reportError(error, { op: "admin.metric-definitions.ref-ranges.DELETE" });
+    return NextResponse.json(
+      { error: "Failed to delete reference range" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/metric-definitions/[id]/ref-ranges/route.ts
+++ b/web/src/app/api/admin/metric-definitions/[id]/ref-ranges/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+import { isValidUUID } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/metric-definitions/[id]/ref-ranges
+ * Add a reference range for a metric definition.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id } = await params;
+
+    if (!isValidUUID(id)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify definition exists
+    const existing = await sql`
+      SELECT id FROM metric_definitions WHERE id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { sex, ageMin, ageMax, refLow, refHigh } = body;
+
+    // Validate sex
+    if (sex !== null && sex !== undefined && !["M", "F"].includes(sex)) {
+      return NextResponse.json(
+        { error: "sex must be null, 'M', or 'F'" },
+        { status: 400 },
+      );
+    }
+
+    // Validate age bounds
+    if (ageMin !== null && ageMin !== undefined && (typeof ageMin !== "number" || ageMin < 0)) {
+      return NextResponse.json(
+        { error: "ageMin must be a non-negative number or null" },
+        { status: 400 },
+      );
+    }
+    if (ageMax !== null && ageMax !== undefined && (typeof ageMax !== "number" || ageMax < 0)) {
+      return NextResponse.json(
+        { error: "ageMax must be a non-negative number or null" },
+        { status: 400 },
+      );
+    }
+
+    // At least one of refLow or refHigh should be provided
+    if (
+      (refLow === null || refLow === undefined) &&
+      (refHigh === null || refHigh === undefined)
+    ) {
+      return NextResponse.json(
+        { error: "At least one of refLow or refHigh is required" },
+        { status: 400 },
+      );
+    }
+
+    const result = await sql`
+      INSERT INTO metric_ref_ranges (metric_definition_id, sex, age_min, age_max, ref_low, ref_high)
+      VALUES (
+        ${id},
+        ${sex || null},
+        ${ageMin ?? null},
+        ${ageMax ?? null},
+        ${refLow ?? null},
+        ${refHigh ?? null}
+      )
+      RETURNING id
+    `;
+
+    return NextResponse.json({ id: result[0].id }, { status: 201 });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: "A reference range with these parameters already exists" },
+        { status: 409 },
+      );
+    }
+    reportError(error, { op: "admin.metric-definitions.ref-ranges.POST" });
+    return NextResponse.json(
+      { error: "Failed to create reference range" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/metric-definitions/[id]/route.ts
+++ b/web/src/app/api/admin/metric-definitions/[id]/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+import { isValidUUID } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/metric-definitions/[id]
+ * Get a single metric definition with all related data.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id } = await params;
+
+    if (!isValidUUID(id)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Fetch definition
+    const definitions = await sql`
+      SELECT id, key, category, canonical_unit, value_type, created_at
+      FROM metric_definitions
+      WHERE id = ${id}
+    `;
+
+    if (definitions.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Fetch related data in parallel
+    const [translations, aliases, refRanges] = await Promise.all([
+      sql`
+        SELECT id, locale, display_name
+        FROM metric_translations
+        WHERE metric_definition_id = ${id}
+        ORDER BY locale ASC
+      `,
+      sql`
+        SELECT id, alias, canonical_name
+        FROM metric_aliases
+        WHERE metric_definition_id = ${id}
+        ORDER BY alias ASC
+      `,
+      sql`
+        SELECT id, sex, age_min, age_max, ref_low, ref_high
+        FROM metric_ref_ranges
+        WHERE metric_definition_id = ${id}
+        ORDER BY sex NULLS FIRST, age_min NULLS FIRST
+      `,
+    ]);
+
+    return NextResponse.json({
+      ...definitions[0],
+      translations,
+      aliases,
+      refRanges,
+    });
+  } catch (error) {
+    reportError(error, { op: "admin.metric-definitions.GET.single" });
+    return NextResponse.json(
+      { error: "Failed to fetch metric definition" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * PUT /api/admin/metric-definitions/[id]
+ * Update a metric definition.
+ */
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id } = await params;
+
+    if (!isValidUUID(id)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { key, category, canonicalUnit, valueType } = body;
+
+    // Verify exists
+    const existing = await sql`
+      SELECT id FROM metric_definitions WHERE id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Build update - only update fields that were explicitly passed
+    await sql`
+      UPDATE metric_definitions
+      SET
+        key = COALESCE(${key || null}, key),
+        category = CASE WHEN ${category === undefined} THEN category ELSE ${category || null} END,
+        canonical_unit = CASE WHEN ${canonicalUnit === undefined} THEN canonical_unit ELSE ${canonicalUnit || null} END,
+        value_type = COALESCE(${valueType || null}, value_type)
+      WHERE id = ${id}
+    `;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: "A metric definition with this key already exists" },
+        { status: 409 },
+      );
+    }
+    reportError(error, { op: "admin.metric-definitions.PUT" });
+    return NextResponse.json(
+      { error: "Failed to update metric definition" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/metric-definitions/[id]
+ * Delete a metric definition and cascade to related data.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id } = await params;
+
+    if (!isValidUUID(id)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify exists
+    const existing = await sql`
+      SELECT id FROM metric_definitions WHERE id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Delete related data first (foreign keys may not cascade)
+    await sql`DELETE FROM metric_translations WHERE metric_definition_id = ${id}`;
+    await sql`DELETE FROM metric_ref_ranges WHERE metric_definition_id = ${id}`;
+    await sql`UPDATE metric_aliases SET metric_definition_id = NULL WHERE metric_definition_id = ${id}`;
+
+    // Delete definition
+    await sql`DELETE FROM metric_definitions WHERE id = ${id}`;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    reportError(error, { op: "admin.metric-definitions.DELETE" });
+    return NextResponse.json(
+      { error: "Failed to delete metric definition" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/metric-definitions/[id]/translations/[translationId]/route.ts
+++ b/web/src/app/api/admin/metric-definitions/[id]/translations/[translationId]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+import { isValidUUID } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * PUT /api/admin/metric-definitions/[id]/translations/[translationId]
+ * Update a translation.
+ */
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string; translationId: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id, translationId } = await params;
+
+    if (!isValidUUID(id) || !isValidUUID(translationId)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify translation exists and belongs to this definition
+    const existing = await sql`
+      SELECT id FROM metric_translations
+      WHERE id = ${translationId} AND metric_definition_id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { locale, displayName } = body;
+
+    if (locale !== undefined && (typeof locale !== "string" || locale.length > 10)) {
+      return NextResponse.json(
+        { error: "locale must be <= 10 characters" },
+        { status: 400 },
+      );
+    }
+
+    if (displayName !== undefined && (typeof displayName !== "string" || displayName.length > 200)) {
+      return NextResponse.json(
+        { error: "displayName must be <= 200 characters" },
+        { status: 400 },
+      );
+    }
+
+    await sql`
+      UPDATE metric_translations
+      SET
+        locale = COALESCE(${locale || null}, locale),
+        display_name = COALESCE(${displayName || null}, display_name)
+      WHERE id = ${translationId}
+    `;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: "A translation for this locale already exists" },
+        { status: 409 },
+      );
+    }
+    reportError(error, { op: "admin.metric-definitions.translations.PUT" });
+    return NextResponse.json(
+      { error: "Failed to update translation" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/metric-definitions/[id]/translations/[translationId]
+ * Delete a translation.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; translationId: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id, translationId } = await params;
+
+    if (!isValidUUID(id) || !isValidUUID(translationId)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify translation exists and belongs to this definition
+    const existing = await sql`
+      SELECT id FROM metric_translations
+      WHERE id = ${translationId} AND metric_definition_id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await sql`DELETE FROM metric_translations WHERE id = ${translationId}`;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    reportError(error, { op: "admin.metric-definitions.translations.DELETE" });
+    return NextResponse.json(
+      { error: "Failed to delete translation" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/metric-definitions/[id]/translations/route.ts
+++ b/web/src/app/api/admin/metric-definitions/[id]/translations/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+import { isValidUUID } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/metric-definitions/[id]/translations
+ * Add a translation for a metric definition.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const { id } = await params;
+
+    if (!isValidUUID(id)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Verify definition exists
+    const existing = await sql`
+      SELECT id FROM metric_definitions WHERE id = ${id}
+    `;
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { locale, displayName } = body;
+
+    if (!locale || typeof locale !== "string" || locale.length > 10) {
+      return NextResponse.json(
+        { error: "locale is required and must be <= 10 characters" },
+        { status: 400 },
+      );
+    }
+
+    if (!displayName || typeof displayName !== "string" || displayName.length > 200) {
+      return NextResponse.json(
+        { error: "displayName is required and must be <= 200 characters" },
+        { status: 400 },
+      );
+    }
+
+    const result = await sql`
+      INSERT INTO metric_translations (metric_definition_id, locale, display_name)
+      VALUES (${id}, ${locale}, ${displayName})
+      RETURNING id
+    `;
+
+    return NextResponse.json({ id: result[0].id }, { status: 201 });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: "A translation for this locale already exists" },
+        { status: 409 },
+      );
+    }
+    reportError(error, { op: "admin.metric-definitions.translations.POST" });
+    return NextResponse.json(
+      { error: "Failed to create translation" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/metric-definitions/route.ts
+++ b/web/src/app/api/admin/metric-definitions/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { sql } from "@/lib/db";
+import { reportError } from "@/lib/error-reporting";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/metric-definitions
+ * List all metric definitions with counts of translations, aliases, and ref ranges.
+ */
+export async function GET(request: Request) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const url = new URL(request.url);
+    const search = url.searchParams.get("search") || "";
+    const category = url.searchParams.get("category") || "";
+
+    const rows = await sql`
+      SELECT
+        md.id,
+        md.key,
+        md.category,
+        md.canonical_unit,
+        md.value_type,
+        md.created_at,
+        COALESCE(t.cnt, 0)::int AS translation_count,
+        COALESCE(a.cnt, 0)::int AS alias_count,
+        COALESCE(r.cnt, 0)::int AS ref_range_count
+      FROM metric_definitions md
+      LEFT JOIN (
+        SELECT metric_definition_id, COUNT(*)::int AS cnt
+        FROM metric_translations
+        GROUP BY metric_definition_id
+      ) t ON t.metric_definition_id = md.id
+      LEFT JOIN (
+        SELECT metric_definition_id, COUNT(*)::int AS cnt
+        FROM metric_aliases
+        WHERE metric_definition_id IS NOT NULL
+        GROUP BY metric_definition_id
+      ) a ON a.metric_definition_id = md.id
+      LEFT JOIN (
+        SELECT metric_definition_id, COUNT(*)::int AS cnt
+        FROM metric_ref_ranges
+        GROUP BY metric_definition_id
+      ) r ON r.metric_definition_id = md.id
+      WHERE
+        (${search} = '' OR md.key ILIKE '%' || ${search} || '%')
+        AND (${category} = '' OR md.category = ${category})
+      ORDER BY md.key ASC
+    `;
+
+    // Get distinct categories for filter dropdown
+    const categories = await sql`
+      SELECT DISTINCT category FROM metric_definitions
+      WHERE category IS NOT NULL
+      ORDER BY category ASC
+    `;
+
+    return NextResponse.json({
+      items: rows,
+      categories: categories.map((c) => c.category),
+    });
+  } catch (error) {
+    reportError(error, { op: "admin.metric-definitions.GET" });
+    return NextResponse.json(
+      { error: "Failed to fetch metric definitions" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/admin/metric-definitions
+ * Create a new metric definition.
+ */
+export async function POST(request: Request) {
+  const userId = await requireAdmin();
+  if (!userId)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const body = await request.json();
+    const { key, category, canonicalUnit, valueType } = body;
+
+    if (!key || typeof key !== "string" || key.length > 100) {
+      return NextResponse.json(
+        { error: "key is required and must be <= 100 characters" },
+        { status: 400 },
+      );
+    }
+
+    const vt = valueType || "quantitative";
+    if (!["quantitative", "qualitative"].includes(vt)) {
+      return NextResponse.json(
+        { error: "valueType must be 'quantitative' or 'qualitative'" },
+        { status: 400 },
+      );
+    }
+
+    const result = await sql`
+      INSERT INTO metric_definitions (key, category, canonical_unit, value_type)
+      VALUES (${key}, ${category || null}, ${canonicalUnit || null}, ${vt})
+      RETURNING id
+    `;
+
+    return NextResponse.json({ id: result[0].id }, { status: 201 });
+  } catch (error) {
+    // Check for unique constraint violation
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: "A metric definition with this key already exists" },
+        { status: 409 },
+      );
+    }
+    reportError(error, { op: "admin.metric-definitions.POST" });
+    return NextResponse.json(
+      { error: "Failed to create metric definition" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
Full CRUD for metric definitions with nested management of:
- Translations (locale → display name)
- Aliases (alternate names that resolve to this metric)
- Reference ranges (sex/age-aware normal ranges)

Includes search by key, filter by category, expandable rows with tabbed sub-resource management.