### PR TITLE
fix: update GA4 tag ID to GT-TB7TTJP2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ Any Google account can sign in. Profile access is granted via the `profile_allow
 | Staging     | `staging.viziai.app`            | Preview deploys from feature branches, OAuth enabled |
 | Local       | `localhost:3000`                | Local dev                                            |
 
-**Google Analytics**: `G-TWM75R9VKP` (viziai.app property, Stream ID: 13682442084)
+**Google Analytics**: `GT-TB7TTJP2` (viziai.app property, Stream ID: 13682442084)
 
 ## Deployment
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -54,7 +54,7 @@ export default async function RootLayout({
         <link rel="preconnect" href="https://www.googletagmanager.com" />
         {/* Google Analytics */}
         <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-TWM75R9VKP"
+          src="https://www.googletagmanager.com/gtag/js?id=GT-TB7TTJP2"
           strategy="afterInteractive"
         />
         <Script id="google-analytics" strategy="afterInteractive">
@@ -62,7 +62,7 @@ export default async function RootLayout({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', 'G-TWM75R9VKP');
+            gtag('config', 'GT-TB7TTJP2');
           `}
         </Script>
       </head>


### PR DESCRIPTION
## Summary
- Update Google Analytics tag ID from `G-TWM75R9VKP` to `GT-TB7TTJP2` (Google migrated to GT- prefix)
- The old ID was returning 404 from googletagmanager.com — no client-side analytics were being collected
- Verified locally: gtag loads with 200, visits appear in GA4 realtime

## Test plan
- [x] Verified gtag script loads (200) on localhost with new ID
- [x] Confirmed visit appears in GA4 realtime dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)