### PR TITLE
fix: reduce free report cap to 5

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -6,4 +6,4 @@ export const CHROME_EXTENSION_URL =
   "https://chromewebstore.google.com/detail/mpclbejnnfjjecfnijgogegggbibebka";
 
 /** Maximum number of reports per profile on the free plan. */
-export const FREE_REPORT_CAP = 100;
+export const FREE_REPORT_CAP = 5;


### PR DESCRIPTION
## Summary
- Reduce `FREE_REPORT_CAP` from 100 to 5
- Bot traffic from San Jose hitting /dashboard (20 sessions yesterday, zero signups) — protecting API credits
- ViziAI is maintenance-only, generous free tier no longer needed

## Test plan
- [ ] Verify existing users with >5 reports can still view their reports
- [ ] Verify new users get capped at 5 uploads
- [ ] Verify upload page shows cap warning correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)