### PR TITLE
fix: bypass free report cap for admin users

### DIFF
--- a/web/src/app/api/upload/route.ts
+++ b/web/src/app/api/upload/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
-import { authOptions, getDbUserId, hasProfileAccess } from "@/lib/auth";
+import {
+  authOptions,
+  getDbUserId,
+  hasProfileAccess,
+  isAdmin,
+} from "@/lib/auth";
 import { sql } from "@/lib/db";
 import { FREE_REPORT_CAP } from "@/lib/constants";
 import { put } from "@vercel/blob";
@@ -70,20 +75,23 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
-    const reportCountResult = await sql`
-      SELECT COUNT(*)::int AS count FROM reports WHERE profile_id = ${profileId}
-    `;
-    const reportCount = reportCountResult[0].count;
-    if (reportCount >= FREE_REPORT_CAP) {
-      return NextResponse.json(
-        {
-          error: "Report Cap Reached",
-          message: "Report limit reached for this profile",
-          reportCount,
-          reportCap: FREE_REPORT_CAP,
-        },
-        { status: 403 },
-      );
+    const adminUser = await isAdmin(userId);
+    if (!adminUser) {
+      const reportCountResult = await sql`
+        SELECT COUNT(*)::int AS count FROM reports WHERE profile_id = ${profileId}
+      `;
+      const reportCount = reportCountResult[0].count;
+      if (reportCount >= FREE_REPORT_CAP) {
+        return NextResponse.json(
+          {
+            error: "Report Cap Reached",
+            message: "Report limit reached for this profile",
+            reportCount,
+            reportCap: FREE_REPORT_CAP,
+          },
+          { status: 403 },
+        );
+      }
     }
 
     const arrayBuffer = await file.arrayBuffer();

--- a/web/src/app/upload/page.tsx
+++ b/web/src/app/upload/page.tsx
@@ -9,6 +9,7 @@ import React, {
   Suspense,
 } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { useDropzone } from "react-dropzone";
 import {
   Upload,
@@ -86,6 +87,9 @@ function UploadPageContent(): React.ReactElement {
   const timezone = useTimezone();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { data: session } = useSession();
+  const userIsAdmin =
+    (session?.user as { isAdmin?: boolean })?.isAdmin ?? false;
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [selectedProfileId, setSelectedProfileId] = useState<string>("");
   const [status, setStatus] = useState<UploadStatus>("idle");
@@ -403,6 +407,7 @@ function UploadPageContent(): React.ReactElement {
 
   const selectedProfile = profiles.find((p) => p.id === selectedProfileId);
   const isAtCap =
+    !userIsAdmin &&
     selectedProfile?.report_count !== undefined &&
     selectedProfile.report_count >= FREE_REPORT_CAP;
 

--- a/web/src/components/profile-switcher.tsx
+++ b/web/src/components/profile-switcher.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import {
   Check,
@@ -43,6 +44,9 @@ export function ProfileSwitcher({
   className,
 }: ProfileSwitcherProps) {
   const router = useRouter();
+  const { data: session } = useSession();
+  const userIsAdmin =
+    (session?.user as { isAdmin?: boolean })?.isAdmin ?? false;
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [loading, setLoading] = useState(true);
   const [switching, setSwitching] = useState(false);
@@ -140,15 +144,20 @@ export function ProfileSwitcher({
                     <span
                       className={cn(
                         "text-xs",
-                        profile.report_count >= FREE_REPORT_CAP
+                        !userIsAdmin && profile.report_count >= FREE_REPORT_CAP
                           ? "text-status-warning"
                           : "text-muted-foreground",
                       )}
                     >
-                      {t("reportCount", {
-                        count: profile.report_count,
-                        max: FREE_REPORT_CAP,
-                      })}
+                      {userIsAdmin
+                        ? t("reportCount", {
+                            count: profile.report_count,
+                            max: "∞",
+                          })
+                        : t("reportCount", {
+                            count: profile.report_count,
+                            max: FREE_REPORT_CAP,
+                          })}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Admin users (`is_admin=true`) now bypass the 5-report upload cap
- API skips the count query entirely for admins
- Upload page and profile switcher show `∞` instead of `5` for admin users

## Test plan
- [ ] Login as admin → upload page should not show cap warning even with 5+ reports
- [ ] Login as non-admin → cap still enforced at 5 reports
- [ ] Profile switcher shows `X / ∞` for admin, `X / 5` for others

🤖 Generated with [Claude Code](https://claude.com/claude-code)